### PR TITLE
fix: require needed packages

### DIFF
--- a/aider.el
+++ b/aider.el
@@ -11,7 +11,9 @@
 
 ;;; Code:
 
+(require 'comint)
 (require 'transient)
+(require 'which-func)
 
 (defgroup aider nil
   "Customization group for the Aider package."


### PR DESCRIPTION
Functions from `comint` and `which-func` is used, so we should require them in case they are not loaded before `aider`.