### PR TITLE
doc: fix quote usage in docstring

### DIFF
--- a/aider.el
+++ b/aider.el
@@ -79,7 +79,7 @@ If not in a git repository, an error is raised."
       (aider-buffer-name-from-git-repo-path git-repo-path home-path))))
 
 (defun aider-run-aider ()
-  "Create a comint-based buffer and run 'aider' for interactive conversation."
+  "Create a comint-based buffer and run \"aider\" for interactive conversation."
   (interactive)
   (let* ((buffer-name (aider-buffer-name))
          (command "aider"))


### PR DESCRIPTION
The single quote `'` is converted to a right single quote in the `*Help*` buffer, and the backtick is converted to left single quote. But use single quotes may cause the misunderstanding that `aider` is an elisp symbol, so I use double quotes instead.

P.S. To get a straight quote in the `*Help*`buffer, use `\\='` in the docstring.  