### PR TITLE
Feat: Add aider-ask-question-under-cursor and aider-batch-add-dired-marked-files function

### DIFF
--- a/aider.el
+++ b/aider.el
@@ -62,6 +62,7 @@ This function can be customized or redefined by the user."
     ("q" "Ask Question" aider-ask-question)
     ("t" "Architect Discussion" aider-architect-discussion)
     ("d" "Debug Exception" aider-debug-exception) ;; Menu item for debug command
+    ("Q" "Ask Question Under Cursor" aider-ask-question-under-cursor)
     ]
    ["Other"
     ("g" "General Command" aider-general-command)

--- a/aider.el
+++ b/aider.el
@@ -14,6 +14,7 @@
 (require 'comint)
 (require 'transient)
 (require 'which-func)
+(require 'dired)
 
 (defgroup aider nil
   "Customization group for the Aider package."
@@ -159,6 +160,16 @@ COMMAND should be a string representing the command to send."
     (let ((command (format "/add %s" (expand-file-name buffer-file-name))))
       ;; Use the shared helper function to send the command
       (aider--send-command command t))))
+
+;; New function to add multiple Dired marked files to Aider buffer
+(defun aider-batch-add-dired-marked-files ()
+  "Add multiple Dired marked files to the Aider buffer with the \"/add\" command."
+  (interactive)
+  (let ((files (dired-get-marked-files)))
+    (if files
+        (dolist (file files)
+          (aider--send-command (format "/add %s" (expand-file-name file))))
+      (message "No files marked in Dired."))))
 
 ;; Function to send a custom command to corresponding aider buffer
 (defun aider-general-command ()

--- a/aider.el
+++ b/aider.el
@@ -237,6 +237,13 @@ The command will be formatted as \"/architect \" followed by the user command an
   (aider-add-current-file)
   (aider--send-command (concat prefix command)))
 
+;; New function to send "ask <line under cursor>" to the Aider buffer
+(defun aider-ask-question-under-cursor ()
+  "Send the command \"ask <line under cursor>\" to the Aider buffer."
+  (interactive)
+  (let ((line (thing-at-point 'line t)))
+    (aider--send-command (concat "/ask " (string-trim line)))))
+
 (provide 'aider)
 
 ;;; aider.el ends here


### PR DESCRIPTION
Added two interactive functions:

1. aider-batch-add-dired-marked-files: user can mark multiple files inside dired buffer (it can also be a find-name-dired output buffer). and call these function to batch add multiple files
2. aider-ask-question-under-cursor: user can have a aider question specific file, write down question there, and call this function to send the question under cursor to aider buffer.