### PR TITLE
change aider prefix for DOOM emacs from l to A

### DIFF
--- a/README.org
+++ b/README.org
@@ -62,10 +62,10 @@
   (setq aider-args '("--model" "gpt-4o-mini")))
 #+END_SRC
 
-The aider prefix is "l".
+The aider prefix is "A".
 
-- Start and open the aider buffer: =[SPC] l o=
-- Add the current file with =[SPC] l a c=
+- Start and open the aider buffer: =[SPC] A o=
+- Add the current file with =[SPC] A a c=
 
 [[file:./doom-menus.png]]
 

--- a/aider-doom.el
+++ b/aider-doom.el
@@ -13,7 +13,7 @@
   (when (and (featurep 'doom-keybinds)
              (vc-backend (or (buffer-file-name) default-directory)))
     (map! :leader
-          (:prefix ("l" . "Aider")
+          (:prefix ("A" . "Aider")
                    (:prefix ("a" . "Add")
                     :desc "Current file" "c" #'aider-add-current-file
                     :desc "Files in window" "w" #'aider-add-files-in-current-window


### PR DESCRIPTION
To address feedback in https://github.com/tninja/aider.el/issues/16