### PR TITLE
Feat: Highlight the comint buffer based on initial buffer major mode

### DIFF
--- a/aider-helm.el
+++ b/aider-helm.el
@@ -26,7 +26,7 @@ HISTORY-FILE-NAME is the base name for history file."
       (with-temp-file history-file
         (let ((history-entries (cl-subseq history
                                          0 (min (length history)
-                                              1000))))  ; Keep last 1000 entries
+                                              10000))))  ; Keep last 10000 entries
           (insert (prin1-to-string history-entries)))))
     input))
 

--- a/aider.el
+++ b/aider.el
@@ -42,6 +42,7 @@
   "Font lock keywords for aider buffer.")
 
 
+;;;###autoload
 (defun aider-plain-read-string (prompt &optional initial-input)
   "Read a string from the user with PROMPT and optional INITIAL-INPUT.
 This function can be customized or redefined by the user."
@@ -129,6 +130,7 @@ If not in a git repository, an error is raised."
               font-lock-keywords-only source-keywords-only
               font-lock-keywords-case-fold-search source-keywords-case-fold-search)))))
 
+;;;###autoload
 (defun aider-run-aider ()
   "Create a comint-based buffer and run \"aider\" for interactive conversation."
   (interactive)
@@ -146,6 +148,7 @@ If not in a git repository, an error is raised."
     (aider-switch-to-buffer)))
 
 ;; Function to switch to the Aider buffer
+;;;###autoload
 (defun aider-switch-to-buffer ()
   "Switch to the Aider buffer."
   (interactive)
@@ -155,16 +158,19 @@ If not in a git repository, an error is raised."
       (message "Aider buffer '%s' does not exist." (aider-buffer-name)))))
 
 ;; Function to reset the Aider buffer
+;;;###autoload
 (defun aider-clear ()
   "Send the command \"/clear\" to the Aider buffer."
   (interactive)
   (aider--send-command "/clear"))
 
+;;;###autoload
 (defun aider-reset ()
   "Send the command \"/reset\" to the Aider buffer."
   (interactive)
   (aider--send-command "/reset"))
 
+;;;###autoload
 (defun aider-exit ()
   "Send the command \"/exit\" to the Aider buffer."
   (interactive)
@@ -207,6 +213,7 @@ COMMAND should be a string representing the command to send."
     (message "Buffer %s does not exist. Please start 'aider' first." (aider-buffer-name))))
 
 ;; Function to send "/add <current buffer file full path>" to corresponding aider buffer
+;;;###autoload
 (defun aider-add-current-file ()
   "Send the command \"/add <current buffer file full path>\" to the corresponding aider comint buffer."
   (interactive)
@@ -218,6 +225,7 @@ COMMAND should be a string representing the command to send."
       (aider--send-command command))))
 
 ;; Function to send "/read <current buffer file full path>" to corresponding aider buffer
+;;;###autoload
 (defun aider-current-file-read-only ()
   "Send the command \"/read-only <current buffer file full path>\" to the corresponding aider comint buffer."
   (interactive)
@@ -229,6 +237,7 @@ COMMAND should be a string representing the command to send."
       (aider--send-command command))))
 
 ;; New function to add files in all buffers in current emacs window
+;;;###autoload
 (defun aider-add-files-in-current-window ()
   "Add files in all buffers in the current Emacs window to the Aider buffer."
   (interactive)
@@ -244,6 +253,7 @@ COMMAND should be a string representing the command to send."
       (message "No files found in the current window."))))
 
 ;; Function to send a custom command to corresponding aider buffer
+;;;###autoload
 (defun aider-general-command ()
   "Prompt the user to input COMMAND and send it to the corresponding aider comint buffer."
   (interactive)
@@ -253,6 +263,7 @@ COMMAND should be a string representing the command to send."
     (aider--send-command command t)))
 
 ;; New function to get command from user and send it prefixed with "/code "
+;;;###autoload
 (defun aider-code-change ()
   "Prompt the user for a command and send it to the corresponding aider comint buffer prefixed with \"/code \"."
   (interactive)
@@ -260,6 +271,7 @@ COMMAND should be a string representing the command to send."
     (aider-send-command-with-prefix "/code " command)))
 
 ;; New function to get command from user and send it prefixed with "/ask "
+;;;###autoload
 (defun aider-ask-question ()
   "Prompt the user for a command and send it to the corresponding aider comint buffer prefixed with \"/ask \"."
   (interactive)
@@ -267,6 +279,7 @@ COMMAND should be a string representing the command to send."
     (aider-send-command-with-prefix "/ask " command)))
 
 ;; New function to get command from user and send it prefixed with "/help "
+;;;###autoload
 (defun aider-help ()
   "Prompt the user for a command and send it to the corresponding aider comint buffer prefixed with \"/help \"."
   (interactive)
@@ -274,6 +287,7 @@ COMMAND should be a string representing the command to send."
     (aider-send-command-with-prefix "/help " command)))
 
 ;; New function to get command from user and send it prefixed with "/architect "
+;;;###autoload
 (defun aider-architect-discussion ()
   "Prompt the user for a command and send it to the corresponding aider comint buffer prefixed with \"/architect \"."
   (interactive)
@@ -281,6 +295,7 @@ COMMAND should be a string representing the command to send."
     (aider-send-command-with-prefix "/architect " command)))
 
 ;; New function to get command from user and send it prefixed with "/ask ", might be tough for AI at this moment
+;;;###autoload
 (defun aider-debug-exception ()
   "Prompt the user for a command and send it to the corresponding aider comint buffer prefixed with \"/debug \",
 replacing all newline characters except for the one at the end."
@@ -289,6 +304,7 @@ replacing all newline characters except for the one at the end."
     (aider--send-command (concat "/ask Investigate the following exception, with current added files as context: " command) t)))
 
 ;; New function to show the last commit using magit
+;;;###autoload
 (defun aider-magit-show-last-commit ()
   "Show the last commit message using Magit.
 If Magit is not installed, report that it is required."
@@ -298,6 +314,7 @@ If Magit is not installed, report that it is required."
     (message "Magit is required to show the last commit.")))
 
 ;; Modified function to get command from user and send it based on selected region
+;;;###autoload
 (defun aider-undo-last-change ()
   "Undo the last change made by Aider."
   (interactive)
@@ -312,6 +329,7 @@ If Magit is not installed, report that it is required."
       (format "/architect \"for the following code block, %s: %s\"\n"
               user-command processed-region-text))))
 
+;;;###autoload
 (defun aider-region-refactor ()
   "Get a command from the user and send it to the corresponding aider comint buffer based on the selected region.
 The command will be formatted as \"/architect \" followed by the user command and the text from the selected region."
@@ -326,6 +344,7 @@ The command will be formatted as \"/architect \" followed by the user command an
     (message "No region selected.")))
 
 ;; New function to explain the code in the selected region
+;;;###autoload
 (defun aider-region-explain ()
   "Get a command from the user and send it to the corresponding aider comint buffer based on the selected region.
 The command will be formatted as \"/ask \" followed by the text from the selected region."
@@ -352,6 +371,7 @@ The command will be formatted as \"/ask \" followed by the text from the selecte
 ;;; functions for dired related
 
 ;; New function to add multiple Dired marked files to Aider buffer
+;;;###autoload
 (defun aider-batch-add-dired-marked-files ()
   "Add multiple Dired marked files to the Aider buffer with the \"/add\" command."
   (interactive)
@@ -362,6 +382,7 @@ The command will be formatted as \"/ask \" followed by the text from the selecte
       (message "No files marked in Dired."))))
 
 ;; New function to run `find-name-dired` from the Git repository root directory
+;;;###autoload
 (defun aider-repo-find-name-dired (pattern)
   "Run `find-name-dired` from the Git repository root directory with the given PATTERN."
   (interactive "sFind name (pattern): ")
@@ -371,6 +392,7 @@ The command will be formatted as \"/ask \" followed by the text from the selecte
         (message "Not in a git repository")
       (find-name-dired repo-path pattern))))
 
+;;;###autoload
 (defun aider-git-repo-root-dired ()
   "Open a Dired buffer at the root of the current Git repository."
   (interactive)
@@ -383,6 +405,7 @@ The command will be formatted as \"/ask \" followed by the text from the selecte
 ;;; functions for .aider file related
 
 ;; New function to send "<line under cursor>" to the Aider buffer
+;;;###autoload
 (defun aider-send-line-under-cursor ()
   "Send the command \"ask <line under cursor>\" to the Aider buffer."
   (interactive)
@@ -390,6 +413,7 @@ The command will be formatted as \"/ask \" followed by the text from the selecte
     (aider--send-command (string-trim line) t)))
 
 ;;; New function to send the current paragraph to the Aider buffer
+;;;###autoload
 (defun aider-send-paragraph ()
   "Send the current paragraph to the Aider buffer."
   (interactive)
@@ -411,6 +435,7 @@ The command will be formatted as \"/ask \" followed by the text from the selecte
   "Keymap for Aider Minor Mode.")
 
 ;; Define the Aider Minor Mode
+;;;###autoload
 (define-minor-mode aider-minor-mode
   "Minor mode for Aider with keybindings."
   :lighter " Aider"

--- a/aider.el
+++ b/aider.el
@@ -145,9 +145,10 @@ If not in a git repository, an error is raised."
         ;; Only inherit syntax highlighting when source buffer is in prog-mode
         (when (with-current-buffer source-buffer
                 (derived-mode-p 'prog-mode))
-          (aider--inherit-source-highlighting source-buffer))
-        (font-lock-mode 1)
-        (font-lock-ensure)))
+          (aider--inherit-source-highlighting source-buffer)
+          (font-lock-mode 1)
+          (font-lock-ensure))
+        ))
     (aider-switch-to-buffer)))
 
 ;; Function to switch to the Aider buffer

--- a/aider.el
+++ b/aider.el
@@ -142,7 +142,10 @@ If not in a git repository, an error is raised."
       (with-current-buffer buffer-name
         (comint-mode)
         (font-lock-add-keywords nil aider-font-lock-keywords t)
-        (aider--inherit-source-highlighting source-buffer)
+        ;; Only inherit syntax highlighting when source buffer is in prog-mode
+        (when (with-current-buffer source-buffer
+                (derived-mode-p 'prog-mode))
+          (aider--inherit-source-highlighting source-buffer))
         (font-lock-mode 1)
         (font-lock-ensure)))
     (aider-switch-to-buffer)))

--- a/aider.el
+++ b/aider.el
@@ -147,7 +147,9 @@ If not in a git repository, an error is raised."
                 (derived-mode-p 'prog-mode))
           (aider--inherit-source-highlighting source-buffer)
           (font-lock-mode 1)
-          (font-lock-ensure))
+          (font-lock-ensure)
+          (message "Aider buffer syntax highlighting inherited from %s" 
+                   (with-current-buffer source-buffer major-mode)))
         ))
     (aider-switch-to-buffer)))
 

--- a/aider.el
+++ b/aider.el
@@ -124,7 +124,7 @@ If not in a git repository, an error is raised."
         (comint-mode)
         (font-lock-add-keywords nil aider-font-lock-keywords t)))
     ;; Switch to the buffer
-    (pop-to-buffer buffer-name)))
+    (aider-switch-to-buffer)))
 
 ;; Function to switch to the Aider buffer
 (defun aider-switch-to-buffer ()


### PR DESCRIPTION
Eg. if the initial buffer major mode is emacs-lisp-mode, the aider buffer will highlight emacs lisp keyword; if initial buffer major mode is python-mode, the aider buffer will highlight python keyword

also bring back the ###autoload, and increase aider-helm.el history size limit