### PR TITLE
Use projectile root if available

### DIFF
--- a/aider.el
+++ b/aider.el
@@ -137,7 +137,13 @@ If not in a git repository, an error is raised."
   (interactive)
   (let* ((buffer-name (aider-buffer-name))
          (comint-terminfo-terminal "dumb")
-         (source-buffer (window-buffer (selected-window))))
+         (source-buffer (window-buffer (selected-window)))
+         ;; Add Projectile support: use project root if available
+         (default-directory 
+           (if (and (fboundp 'projectile-project-root)
+                    (projectile-project-p))
+               (projectile-project-root)
+             default-directory)))
     (unless (comint-check-proc buffer-name)
       (apply 'make-comint-in-buffer "aider" buffer-name aider-program nil aider-args)
       (with-current-buffer buffer-name


### PR DESCRIPTION
If projectile is available, use its root directory to set as current directory when creating a comint buffer. This way aider --subtree-only will start correctly in the project root, not in the semi-random location related to current file.

I tested it and it seems to work well. Would be great if someone **without** projectile could confirm it does not break anything (although it really should not).

Addresses #23 