### PR TITLE
Fix: Make aider.el work with tramp

### DIFF
--- a/README.org
+++ b/README.org
@@ -47,6 +47,8 @@ You can add your own Elisp functions to support your specific use cases. Feel fr
 
 * Installation
 
+- Emacs need to be >= 2.61
+
 ** Vanilla Emacs Installation
 - [[https://aider.chat/docs/install.html][Install aider]]
 - Install the dependency [[https://github.com/magit/transient][Transient]] using your package manager.

--- a/README.org
+++ b/README.org
@@ -102,27 +102,11 @@ The aider prefix is "A".
 
 Helm enables fuzzy searching functionality for command history prompts
 
-You can enable Helm-based completion in two ways:
-
-- 1. Using use-package:
+You can enable Helm-based completion with the following code:
 
 #+BEGIN_SRC emacs-lisp
-  ;; Basic aider installation
   (use-package aider
-    :straight (:host github :repo "tninja/aider.el" :files ("aider.el")))
-
-  ;; Optional helm support
-  (use-package aider-helm
-    :straight (:host github :repo "tninja/aider.el" :files ("aider-helm.el"))
-    :after (aider helm))
-#+END_SRC
-
-- 2. Manual loading:
-
-#+BEGIN_SRC emacs-lisp
-  ;; Load helm support after both aider and helm are loaded
-  (with-eval-after-load 'helm
-    (require 'aider-helm))
+    :straight (:host github :repo "tninja/aider.el" :files ("aider.el" "aider-helm.el")))
 #+END_SRC
   
 *** Aider script interactive mode: aider-minor-mode

--- a/README.org
+++ b/README.org
@@ -47,7 +47,7 @@ You can add your own Elisp functions to support your specific use cases. Feel fr
 
 * Installation
 
-- Emacs need to be >= 2.61
+- Emacs need to be >= 26.1
 
 ** Vanilla Emacs Installation
 - [[https://aider.chat/docs/install.html][Install aider]]

--- a/aider.el
+++ b/aider.el
@@ -252,7 +252,7 @@ Ensure proper highlighting of the text in the buffer."
                                                      'rear-nonsticky t))))
         ;; Send raw text to process
         (process-send-string process chunk)
-        (sleep-for 0.1)
+        (sleep-for 0.2)
         ;; (message "Sent command to aider buffer: %s" chunk)
         (setq pos end-pos)))))
 

--- a/aider.el
+++ b/aider.el
@@ -2,7 +2,7 @@
 
 ;; Author: Kang Tu <tninja@gmail.com>
 ;; Version: 0.2.0
-;; Package-Requires: ((emacs "25.1") (transient "0.3.0"))
+;; Package-Requires: ((emacs "26.1") (transient "0.3.0"))
 ;; Keywords: convenience, tools
 ;; URL: https://github.com/tninja/aider.el
 
@@ -292,7 +292,8 @@ COMMAND should be a string representing the command to send."
   ;; Ensure the current buffer is associated with a file
   (if (not buffer-file-name)
       (message "Current buffer is not associated with a file.")
-    (let ((command (format "%s %s" (aider--get-add-command-prefix) (expand-file-name buffer-file-name))))
+    (let ((command (format "%s %s" (aider--get-add-command-prefix)
+                           (file-local-name (expand-file-name buffer-file-name)))))
       ;; Use the shared helper function to send the command
       (aider--send-command command))))
 


### PR DESCRIPTION
As described at https://github.com/tninja/aider.el/issues/36

Thanks @artyom-smushkov for the feedback and the solution to this

The change require emacs 26.1