### PR TITLE
Fix: Use correct prefix in aider-add-or-read-current-file

### DIFF
--- a/aider.el
+++ b/aider.el
@@ -292,7 +292,7 @@ COMMAND should be a string representing the command to send."
   ;; Ensure the current buffer is associated with a file
   (if (not buffer-file-name)
       (message "Current buffer is not associated with a file.")
-    (let ((command (format "%s %s" (aider--get-add-command-prefix)
+    (let ((command (format "%s %s" command-prefix
                            (file-local-name (expand-file-name buffer-file-name)))))
       ;; Use the shared helper function to send the command
       (aider--send-command command))))
@@ -302,7 +302,7 @@ COMMAND should be a string representing the command to send."
 (defun aider-add-current-file ()
   "Send the command \"/add <current buffer file full path>\" to the corresponding aider comint buffer."
   (interactive)
-  (aider-add-or-read-current-file "/add"))
+  (aider-add-or-read-current-file (aider--get-add-command-prefix)))
 
 ;; New function to add files in all buffers in current emacs window
 ;;;###autoload


### PR DESCRIPTION
The `aider-add-or-read-current-file` function was incorrectly constructing the command to add a file to the aider chat, always using the `/add` prefix regardless of the value of `aider--add-file-read-only`.

This commit fixes the issue by ensuring that the function correctly uses the prefix returned by `aider--get-add-command-prefix`, which will be `/read-only` when `aider--add-file-read-only` is non-nil.

Specifically, the following changes were made:

- Modified `aider-add-or-read-current-file` to use the `command-prefix` argument when constructing the command string.
- Updated `aider-add-current-file` to pass the result of `aider--get-add-command-prefix` to `aider-add-or-read-current-file`.

This ensures that files are added with the correct prefix based on the user's configuration, allowing for proper read-only mode functionality.