### PR TITLE
Feat: Add aider-send-region function

### DIFF
--- a/README.org
+++ b/README.org
@@ -111,7 +111,7 @@ You can enable Helm-based completion with the following code:
   
 *** Aider script interactive mode: aider-minor-mode
 
-- If you prefer writing Aider commands in a separate file and sending them to an Aider session (similar to working with Python or R scripts and sending code blocks to a REPL), you might want to try aider-minor-mode. It by default bind C-c C-n to send current line to aider session, and C-c C-c to send current region to aider session.
+- If you prefer writing Aider commands in a separate file and sending them to an Aider session (similar to working with Python or R scripts and sending code blocks to a REPL), you might want to try aider-minor-mode. It by default bind C-c C-n to send current line to aider session, and C-c C-c to send current paragraph line by line to aider session.
   - Enable aider-minor-mode for your editing buffer
   - To automatically enable aider-minor-mode for any file with "aider" in its filename:
 

--- a/README.org
+++ b/README.org
@@ -111,7 +111,10 @@ You can enable Helm-based completion with the following code:
   
 *** Aider script interactive mode: aider-minor-mode
 
-- If you prefer writing Aider commands in a separate file and sending them to an Aider session (similar to working with Python or R scripts and sending code blocks to a REPL), you might want to try aider-minor-mode. It by default bind C-c C-n to send current line to aider session, and C-c C-c to send current paragraph line by line to aider session.
+- If you prefer writing Aider commands in a separate file and sending them to an Aider session (similar to working with Python or R scripts and sending code blocks to a REPL), you might want to try aider-minor-mode. It provides the following key bindings:
+  - C-c C-n: Send current line to aider session
+  - C-c C-c: Send current paragraph line by line to aider session
+  - C-c C-b: Send current paragraph as a single block to aider session
   - Enable aider-minor-mode for your editing buffer
   - To automatically enable aider-minor-mode for any file with "aider" in its filename:
 

--- a/README.org
+++ b/README.org
@@ -115,6 +115,7 @@ You can enable Helm-based completion with the following code:
   - C-c C-n: Send current line to aider session
   - C-c C-c: Send current paragraph line by line to aider session
   - C-c C-b: Send current paragraph as a single block to aider session
+  - C-c C-r: Send current region as a single block to aider session
   - Enable aider-minor-mode for your editing buffer
   - To automatically enable aider-minor-mode for any file with "aider" in its filename:
 

--- a/README.org
+++ b/README.org
@@ -114,7 +114,6 @@ You can enable Helm-based completion with the following code:
 - If you prefer writing Aider commands in a separate file and sending them to an Aider session (similar to working with Python or R scripts and sending code blocks to a REPL), you might want to try aider-minor-mode. It provides the following key bindings:
   - C-c C-n: Send current line to aider session
   - C-c C-c: Send current paragraph line by line to aider session
-  - C-c C-b: Send current paragraph as a single block to aider session
   - C-c C-r: Send current region as a single block to aider session
   - Enable aider-minor-mode for your editing buffer
   - To automatically enable aider-minor-mode for any file with "aider" in its filename:

--- a/aider-doom.el
+++ b/aider-doom.el
@@ -30,6 +30,7 @@
                    (:prefix ("s" . "Send")
                     :desc "Line at cursor" "l" #'aider-send-line-under-cursor
                     :desc "Paragraph at cursor, line by line" "p" #'aider-send-paragraph-by-line
+                    :desc "Paragraph at cursor as block" "b" #'aider-send-block
                     )
 
                    (:prefix ("c" . "Code")

--- a/aider-doom.el
+++ b/aider-doom.el
@@ -30,7 +30,6 @@
                    (:prefix ("s" . "Send")
                     :desc "Line at cursor" "l" #'aider-send-line-under-cursor
                     :desc "Paragraph at cursor, line by line" "p" #'aider-send-paragraph-by-line
-                    :desc "Paragraph at cursor as block" "b" #'aider-send-block
                     :desc "Region as block" "r" #'aider-send-region
                     )
 

--- a/aider-doom.el
+++ b/aider-doom.el
@@ -31,6 +31,7 @@
                     :desc "Line at cursor" "l" #'aider-send-line-under-cursor
                     :desc "Paragraph at cursor, line by line" "p" #'aider-send-paragraph-by-line
                     :desc "Paragraph at cursor as block" "b" #'aider-send-block
+                    :desc "Region as block" "r" #'aider-send-region
                     )
 
                    (:prefix ("c" . "Code")

--- a/aider-doom.el
+++ b/aider-doom.el
@@ -29,7 +29,7 @@
 
                    (:prefix ("s" . "Send")
                     :desc "Line at cursor" "l" #'aider-send-line-under-cursor
-                    :desc "Paragraph at cursor" "p" #'aider-send-paragraph
+                    :desc "Paragraph at cursor, line by line" "p" #'aider-send-paragraph-by-line
                     )
 
                    (:prefix ("c" . "Code")

--- a/aider.el
+++ b/aider.el
@@ -561,7 +561,19 @@ This function assumes the cursor is on or inside a test function."
         (aider--send-command command t))
     (message "No test function found at cursor position.")))
 
-;;; functions for .aider file related
+;;; functions for sending text blocks
+
+;;;###autoload
+(defun aider-send-block ()
+  "Get the whole text of the current paragraph and send it as a single block to aider session."
+  (interactive)
+  (let ((paragraph (save-excursion
+                    (backward-paragraph)
+                    (let ((start (point)))
+                      (forward-paragraph)
+                      (buffer-substring-no-properties start (point))))))
+    (unless (string-empty-p paragraph)
+      (aider--send-command paragraph t))))
 
 ;; New function to send "<line under cursor>" to the Aider buffer
 ;;;###autoload
@@ -593,6 +605,7 @@ This function assumes the cursor is on or inside a test function."
   (let ((map (make-sparse-keymap)))
     (define-key map (kbd "C-c C-n") 'aider-send-line-under-cursor)
     (define-key map (kbd "C-c C-c") 'aider-send-paragraph-by-line)
+    (define-key map (kbd "C-c C-b") 'aider-send-block)
     map)
   "Keymap for Aider Minor Mode.")
 

--- a/aider.el
+++ b/aider.el
@@ -588,24 +588,12 @@ This function assumes the cursor is on or inside a test function."
               (aider--send-command line t)))
           (split-string paragraph "\n" t))))
 
-;;;###autoload
-(defun aider-send-block ()
-  "Get the whole text of the current paragraph and send it as a single block to aider session."
-  (interactive)
-  (let ((paragraph (save-excursion
-                    (backward-paragraph)
-                    (let ((start (point)))
-                      (forward-paragraph)
-                      (buffer-substring-no-properties start (point))))))
-    (unless (string-empty-p paragraph)
-      (aider--send-command paragraph t))))
 
 ;; Define the keymap for Aider Minor Mode
 (defvar aider-minor-mode-map
   (let ((map (make-sparse-keymap)))
     (define-key map (kbd "C-c C-n") 'aider-send-line-under-cursor)
     (define-key map (kbd "C-c C-c") 'aider-send-paragraph-by-line)
-    (define-key map (kbd "C-c C-b") 'aider-send-block)
     (define-key map (kbd "C-c C-r") 'aider-send-region)
     map)
   "Keymap for Aider Minor Mode.")

--- a/aider.el
+++ b/aider.el
@@ -606,6 +606,7 @@ This function assumes the cursor is on or inside a test function."
     (define-key map (kbd "C-c C-n") 'aider-send-line-under-cursor)
     (define-key map (kbd "C-c C-c") 'aider-send-paragraph-by-line)
     (define-key map (kbd "C-c C-b") 'aider-send-block)
+    (define-key map (kbd "C-c C-r") 'aider-send-region)
     map)
   "Keymap for Aider Minor Mode.")
 
@@ -618,6 +619,16 @@ This function assumes the cursor is on or inside a test function."
 
 (when (featurep 'doom)
   (require 'aider-doom))
+
+;;;###autoload
+(defun aider-send-region ()
+  "Send the current active region text as a whole block to aider session."
+  (interactive)
+  (if (region-active-p)
+      (let ((region-text (buffer-substring-no-properties (region-beginning) (region-end))))
+        (unless (string-empty-p region-text)
+          (aider--send-command region-text t)))
+    (message "No region selected.")))
 
 (provide 'aider)
 

--- a/aider.el
+++ b/aider.el
@@ -588,6 +588,15 @@ This function assumes the cursor is on or inside a test function."
               (aider--send-command line t)))
           (split-string paragraph "\n" t))))
 
+;;;###autoload
+(defun aider-send-region ()
+  "Send the current active region text as a whole block to aider session."
+  (interactive)
+  (if (region-active-p)
+      (let ((region-text (buffer-substring-no-properties (region-beginning) (region-end))))
+        (unless (string-empty-p region-text)
+          (aider--send-command region-text t)))
+    (message "No region selected.")))
 
 ;; Define the keymap for Aider Minor Mode
 (defvar aider-minor-mode-map
@@ -607,16 +616,6 @@ This function assumes the cursor is on or inside a test function."
 
 (when (featurep 'doom)
   (require 'aider-doom))
-
-;;;###autoload
-(defun aider-send-region ()
-  "Send the current active region text as a whole block to aider session."
-  (interactive)
-  (if (region-active-p)
-      (let ((region-text (buffer-substring-no-properties (region-beginning) (region-end))))
-        (unless (string-empty-p region-text)
-          (aider--send-command region-text t)))
-    (message "No region selected.")))
 
 (provide 'aider)
 

--- a/aider.el
+++ b/aider.el
@@ -573,7 +573,7 @@ This function assumes the cursor is on or inside a test function."
 
 ;;; New function to send the current paragraph to the Aider buffer
 ;;;###autoload
-(defun aider-send-paragraph ()
+(defun aider-send-paragraph-by-line ()
   "Get the whole text of the current paragraph, split them into lines,
    strip the newline character from each line,
    for each non-empty line, send it to aider session"
@@ -592,7 +592,7 @@ This function assumes the cursor is on or inside a test function."
 (defvar aider-minor-mode-map
   (let ((map (make-sparse-keymap)))
     (define-key map (kbd "C-c C-n") 'aider-send-line-under-cursor)
-    (define-key map (kbd "C-c C-c") 'aider-send-paragraph)
+    (define-key map (kbd "C-c C-c") 'aider-send-paragraph-by-line)
     map)
   "Keymap for Aider Minor Mode.")
 

--- a/aider.el
+++ b/aider.el
@@ -563,18 +563,6 @@ This function assumes the cursor is on or inside a test function."
 
 ;;; functions for sending text blocks
 
-;;;###autoload
-(defun aider-send-block ()
-  "Get the whole text of the current paragraph and send it as a single block to aider session."
-  (interactive)
-  (let ((paragraph (save-excursion
-                    (backward-paragraph)
-                    (let ((start (point)))
-                      (forward-paragraph)
-                      (buffer-substring-no-properties start (point))))))
-    (unless (string-empty-p paragraph)
-      (aider--send-command paragraph t))))
-
 ;; New function to send "<line under cursor>" to the Aider buffer
 ;;;###autoload
 (defun aider-send-line-under-cursor ()
@@ -599,6 +587,18 @@ This function assumes the cursor is on or inside a test function."
             (unless (string-empty-p line)
               (aider--send-command line t)))
           (split-string paragraph "\n" t))))
+
+;;;###autoload
+(defun aider-send-block ()
+  "Get the whole text of the current paragraph and send it as a single block to aider session."
+  (interactive)
+  (let ((paragraph (save-excursion
+                    (backward-paragraph)
+                    (let ((start (point)))
+                      (forward-paragraph)
+                      (buffer-substring-no-properties start (point))))))
+    (unless (string-empty-p paragraph)
+      (aider--send-command paragraph t))))
 
 ;; Define the keymap for Aider Minor Mode
 (defvar aider-minor-mode-map


### PR DESCRIPTION
It is useful when we need to describe the design in multiple lines in a design doc, and ask aider to implement the design.