### PR TITLE
git_repo_path works for submodules.

### DIFF
--- a/README.org
+++ b/README.org
@@ -1,4 +1,4 @@
-#+TITLE: aider.el : aider (AI Pair Programming) Inside Emacs 
+#+TITLE: aider.el : aider (AI Pair Programming) Inside Emacs
 
 * Introduction
 
@@ -42,7 +42,7 @@
 *** Support for Test Driven Development:
   - (`aider-fix-failing-test-under-cursor`): Place cursor on a failing test function and ask Aider to analyze and fix the code to make tests pass.
 
-*** And More: 
+*** And More:
 You can add your own Elisp functions to support your specific use cases. Feel free to ask Aider/`aider.el` to help you create them.
 
 * Installation
@@ -52,13 +52,14 @@ You can add your own Elisp functions to support your specific use cases. Feel fr
 ** Vanilla Emacs Installation
 - [[https://aider.chat/docs/install.html][Install aider]]
 - Install the dependency [[https://github.com/magit/transient][Transient]] using your package manager.
+- Install the dependency [[https://github.com/magit/magit][Magit]] using your package manager.
 - Install aider.el with the following code:
 
 #+BEGIN_SRC emacs-lisp
   (use-package aider
     :straight (:host github :repo "tninja/aider.el" :files ("aider.el"))
     :config
-    ;; Use claude-3-5-sonnet cause it is best in aider benchmark 
+    ;; Use claude-3-5-sonnet cause it is best in aider benchmark
     (setq aider-args '("--model" "anthropic/claude-3-5-sonnet-20241022"))
     (setenv "ANTHROPIC_API_KEY" anthropic-api-key)
     ;; Or use chatgpt model since it is most well known
@@ -108,7 +109,7 @@ You can enable Helm-based completion with the following code:
   (use-package aider
     :straight (:host github :repo "tninja/aider.el" :files ("aider.el" "aider-helm.el")))
 #+END_SRC
-  
+
 *** Aider script interactive mode: aider-minor-mode
 
 - If you prefer writing Aider commands in a separate file and sending them to an Aider session (similar to working with Python or R scripts and sending code blocks to a REPL), you might want to try aider-minor-mode. It provides the following key bindings:
@@ -142,4 +143,3 @@ You can enable Helm-based completion with the following code:
   - [[https://github.com/xenodium/chatgpt-shell][chatgpt-shell]]: ChatGPT and DALL-E Emacs shells + Org Babel
   - [[https://github.com/copilot-emacs/copilot.el][copilot.el]]: Emacs plugin for GitHub Copilot
   - [[https://github.com/chep/copilot-chat.el][copilot-chat.el]]: Chat with GitHub Copilot in Emacs
-    

--- a/aider.el
+++ b/aider.el
@@ -2,7 +2,7 @@
 
 ;; Author: Kang Tu <tninja@gmail.com>
 ;; Version: 0.2.0
-;; Package-Requires: ((emacs "26.1") (transient "0.3.0"))
+;; Package-Requires: ((emacs "26.1") (transient "0.3.0") (magit "4.0.0"))
 ;; Keywords: convenience, tools
 ;; URL: https://github.com/tninja/aider.el
 
@@ -14,6 +14,7 @@
 (require 'comint)
 (require 'dired)
 (require 'transient)
+(require 'magit)
 (require 'which-func)
 
 (defgroup aider nil
@@ -142,19 +143,13 @@ Affects the system message too.")
 ;; Removed the default key binding
 ;; (global-set-key (kbd "C-c a") 'aider-transient-menu)
 
-(defun aider-buffer-name-from-git-repo-path (git-repo-path)
-  "Generate the Aider buffer name based on the GIT-REPO-PATH.
-If not in a git repository, an error is raised."
-  (let ((hash8 (substring (secure-hash 'md5 git-repo-path) 0 8)))
-    (format "*aider:~%s%s*" git-repo-path hash8)))
-
 (defun aider-buffer-name ()
   "Generate the Aider buffer name based on the git repo of the current active buffer using a git command.
 If not in a git repository, an error is raised."
   (let ((git-repo-path (magit-toplevel)))
     (if (string-match-p "fatal" git-repo-path)
         (error "Not in a git repository")
-      (aider-buffer-name-from-git-repo-path git-repo-path))))
+      (format "*aider:~%s*" git-repo-path))))
 
 (defun aider--inherit-source-highlighting (source-buffer)
   "Inherit syntax highlighting settings from SOURCE-BUFFER."

--- a/aider.el
+++ b/aider.el
@@ -142,20 +142,19 @@ Affects the system message too.")
 ;; Removed the default key binding
 ;; (global-set-key (kbd "C-c a") 'aider-transient-menu)
 
-(defun aider-buffer-name-from-git-repo-path (git-repo-path home-path)
-  "Generate the Aider buffer name based on the GIT-REPO-PATH and HOME-PATH.
+(defun aider-buffer-name-from-git-repo-path (git-repo-path)
+  "Generate the Aider buffer name based on the GIT-REPO-PATH.
 If not in a git repository, an error is raised."
-  (let* ((relative-path (substring git-repo-path (length home-path))))
-    (format "*aider:%s*" (concat "~" (replace-regexp-in-string "\n" "" relative-path)))))
+  (let ((hash8 (substring (secure-hash 'md5 git-repo-path) 0 8)))
+    (format "*aider:~%s%s*" git-repo-path hash8)))
 
 (defun aider-buffer-name ()
-  "Generate the Aider buffer name based on the path from the home folder to the git repo of the current active buffer using a git command.
+  "Generate the Aider buffer name based on the git repo of the current active buffer using a git command.
 If not in a git repository, an error is raised."
-  (let* ((git-repo-path (shell-command-to-string "git rev-parse --show-toplevel"))
-         (home-path (expand-file-name "~")))
+  (let ((git-repo-path (magit-toplevel)))
     (if (string-match-p "fatal" git-repo-path)
         (error "Not in a git repository")
-      (aider-buffer-name-from-git-repo-path git-repo-path home-path))))
+      (aider-buffer-name-from-git-repo-path git-repo-path))))
 
 (defun aider--inherit-source-highlighting (source-buffer)
   "Inherit syntax highlighting settings from SOURCE-BUFFER."
@@ -195,7 +194,7 @@ If not in a git repository, an error is raised."
           (aider--inherit-source-highlighting source-buffer)
           (font-lock-mode 1)
           (font-lock-ensure)
-          (message "Aider buffer syntax highlighting inherited from %s" 
+          (message "Aider buffer syntax highlighting inherited from %s"
                    (with-current-buffer source-buffer major-mode)))
         ))
     (aider-switch-to-buffer)))
@@ -250,7 +249,7 @@ Ensure proper highlighting of the text in the buffer."
                 (current-point (process-mark process)))
             (goto-char current-point)
             ;; Use comint-output-filter to ensure proper text property handling
-            (comint-output-filter process (propertize chunk 
+            (comint-output-filter process (propertize chunk
                                                      'face 'aider-command-text
                                                      'font-lock-face 'aider-command-text
                                                      'rear-nonsticky t))))
@@ -553,7 +552,7 @@ If there are more than 40 files, refuse to add and show warning message."
 This function assumes the cursor is on or inside a test function."
   (interactive)
   (if-let ((test-function-name (which-function)))
-      (let* ((initial-input (format "The test '%s' is failing. Please analyze and fix the code to make the test pass. Don't break any other test" 
+      (let* ((initial-input (format "The test '%s' is failing. Please analyze and fix the code to make the test pass. Don't break any other test"
                                    test-function-name))
              (test-output (aider-read-string "Architect question: " initial-input))
              (command (format "/architect %s" test-output)))

--- a/aider.el
+++ b/aider.el
@@ -2,7 +2,7 @@
 
 ;; Author: Kang Tu <tninja@gmail.com>
 ;; Version: 0.2.0
-;; Package-Requires: ((emacs "26.1") (transient "0.3.0") (magit "4.0.0"))
+;; Package-Requires: ((emacs "26.1") (transient "0.3.0") (magit "2.1.0"))
 ;; Keywords: convenience, tools
 ;; URL: https://github.com/tninja/aider.el
 


### PR DESCRIPTION
[…l/issues/23](https://github.com/tninja/aider.el/issues/23),

![Screenshot_2025-01-08_13-06-52](https://github.com/user-attachments/assets/53da740d-37a6-4e10-b3bc-4a233e1f1cb1).

Try to make aider working on different git submodules synchronously. It works for my local testing.
