### PR TITLE
Feat: update for aider-minor-mode

### DIFF
--- a/README.org
+++ b/README.org
@@ -114,8 +114,8 @@ You can enable Helm-based completion with the following code:
 *** Aider script interactive mode: aider-minor-mode
 
 - If you prefer writing Aider commands in a separate file and sending them to an Aider session (similar to working with Python or R scripts and sending code blocks to a REPL), you might want to try aider-minor-mode. It provides the following key bindings:
-  - C-c C-n: Send current line to aider session
-  - C-c C-c: Send current paragraph line by line to aider session
+  - C-c C-n: If region is active, send selected region line by line; otherwise, send current line
+  - C-c C-c: Send current region line by line to aider session
   - C-c C-r: Send current region as a single block to aider session
   - Enable aider-minor-mode for your editing buffer
   - To automatically enable aider-minor-mode for any file with "aider" in its filename:

--- a/aider-doom.el
+++ b/aider-doom.el
@@ -29,7 +29,7 @@
 
                    (:prefix ("s" . "Send")
                     :desc "Line at cursor" "l" #'aider-send-line-under-cursor
-                    :desc "Paragraph at cursor, line by line" "p" #'aider-send-paragraph-by-line
+                    :desc "Paragraph at cursor, line by line" "p" #'aider-send-region-by-line
                     :desc "Region as block" "r" #'aider-send-region
                     )
 

--- a/aider.el
+++ b/aider.el
@@ -615,22 +615,23 @@ This function assumes the cursor is on or inside a test function."
   (let ((line (thing-at-point 'line t)))
     (aider--send-command (string-trim line) nil)))
 
-;;; New function to send the current paragraph to the Aider buffer
+;;; New function to send the current selected region line by line to the Aider buffer
 ;;;###autoload
-(defun aider-send-paragraph-by-line ()
-  "Get the whole text of the current paragraph, split them into lines,
-   strip the newline character from each line,
-   for each non-empty line, send it to aider session"
+(defun aider-send-region-by-line ()
+  "Get the text of the current selected region, split them into lines,
+strip the newline character from each line,
+for each non-empty line, send it to aider session.
+If no region is selected, show a message."
   (interactive)
-  (let ((paragraph (save-excursion
-                     (backward-paragraph)
-                     (let ((start (point)))
-                       (forward-paragraph)
-                       (buffer-substring-no-properties start (point))))))
-    (mapc (lambda (line)
-            (unless (string-empty-p line)
-              (aider--send-command line nil)))
-          (split-string paragraph "\n" t))))
+  (if (region-active-p)
+      (let ((region-text (buffer-substring-no-properties 
+                         (region-beginning) 
+                         (region-end))))
+        (mapc (lambda (line)
+                (unless (string-empty-p line)
+                  (aider--send-command line nil)))
+              (split-string region-text "\n" t)))
+    (message "No region selected.")))
 
 ;;;###autoload
 (defun aider-send-region ()
@@ -646,7 +647,7 @@ This function assumes the cursor is on or inside a test function."
 (defvar aider-minor-mode-map
   (let ((map (make-sparse-keymap)))
     (define-key map (kbd "C-c C-n") 'aider-send-line-under-cursor)
-    (define-key map (kbd "C-c C-c") 'aider-send-paragraph-by-line)
+    (define-key map (kbd "C-c C-c") 'aider-send-region-by-line)
     (define-key map (kbd "C-c C-r") 'aider-send-region)
     (define-key map (kbd "C-c C-z") 'aider-switch-to-buffer)
     map)

--- a/aider.el
+++ b/aider.el
@@ -607,13 +607,16 @@ This function assumes the cursor is on or inside a test function."
 
 ;;; functions for sending text blocks
 
-;; New function to send "<line under cursor>" to the Aider buffer
+;; New function to send "<line under cursor>" or region line by line to the Aider buffer
 ;;;###autoload
 (defun aider-send-line-under-cursor ()
-  "Send the command \"ask <line under cursor>\" to the Aider buffer."
+  "If region is active, send the selected region line by line to the Aider buffer.
+Otherwise, send the line under cursor to the Aider buffer."
   (interactive)
-  (let ((line (thing-at-point 'line t)))
-    (aider--send-command (string-trim line) nil)))
+  (if (region-active-p)
+      (aider-send-region-by-line)
+    (let ((line (thing-at-point 'line t)))
+      (aider--send-command (string-trim line) nil))))
 
 ;;; New function to send the current selected region line by line to the Aider buffer
 ;;;###autoload

--- a/aider.el
+++ b/aider.el
@@ -648,6 +648,7 @@ This function assumes the cursor is on or inside a test function."
     (define-key map (kbd "C-c C-n") 'aider-send-line-under-cursor)
     (define-key map (kbd "C-c C-c") 'aider-send-paragraph-by-line)
     (define-key map (kbd "C-c C-r") 'aider-send-region)
+    (define-key map (kbd "C-c C-z") 'aider-switch-to-buffer)
     map)
   "Keymap for Aider Minor Mode.")
 

--- a/aider.el
+++ b/aider.el
@@ -613,7 +613,7 @@ This function assumes the cursor is on or inside a test function."
   "Send the command \"ask <line under cursor>\" to the Aider buffer."
   (interactive)
   (let ((line (thing-at-point 'line t)))
-    (aider--send-command (string-trim line) t)))
+    (aider--send-command (string-trim line) nil)))
 
 ;;; New function to send the current paragraph to the Aider buffer
 ;;;###autoload
@@ -629,7 +629,7 @@ This function assumes the cursor is on or inside a test function."
                        (buffer-substring-no-properties start (point))))))
     (mapc (lambda (line)
             (unless (string-empty-p line)
-              (aider--send-command line t)))
+              (aider--send-command line nil)))
           (split-string paragraph "\n" t))))
 
 ;;;###autoload


### PR DESCRIPTION
1. Don't auto switch to buffer when send line to it. (cause we might need to other things)
2. C-c C-n will send region line by line, if a region selected.
3. C-c C-z will switch to aider session buffer, key binding is as same as ESS