### PR TITLE
Suggest using user's `~/.aider.conf.yml`

### DIFF
--- a/README.org
+++ b/README.org
@@ -71,6 +71,8 @@ If you have Straight installed
     ;; Or use gemini v2 model since it is very good and free
     ;; (setq aider-args '("--model" "gemini/gemini-exp-1206"))
     ;; (setenv "GEMINI_API_KEY" <your-gemini-api-key>)
+    ;; Or use your personal config file
+    ;; (setq aider-args `("--config" ,(expand-file-name "~/.aider.conf.yml")))
     ;; ;;
     ;; Optional: Set a key binding for the transient menu
     (global-set-key (kbd "C-c a") 'aider-transient-menu))
@@ -93,6 +95,8 @@ Add the config
     ;; Or use gemini v2 model since it is very good and free
     ;; (setq aider-args '("--model" "gemini/gemini-exp-1206"))
     ;; (setenv "GEMINI_API_KEY" <your-gemini-api-key>)
+    ;; Or use your personal config file
+    ;; (setq aider-args `("--config" ,(expand-file-name "~/.aider.conf.yml")))
     ;; ;;
     ;; Optional: Set a key binding for the transient menu
     (global-set-key (kbd "C-c a") 'aider-transient-menu))


### PR DESCRIPTION
For users who have already configured aider in `~/.aider.conf.yml`, this suggestion allows them to use this and not have to pass multiple other arguments.