### PR TITLE
Using universal argument prompts user to change `aider-args`

### DIFF
--- a/README.org
+++ b/README.org
@@ -21,6 +21,7 @@
   - (`aider-run-aider`): Creates a comint-based, *git repo-specific Aider session* for interactive conversation.
     - Git repository identification is based on the current file's path
     - Multiple Aider sessions can run simultaneously for different Git repositories
+When being called with the universal argument (`C-u`), a prompt will offer the user to change the content of `aider-args` for this session.
   - (`aider-switch-to-buffer`): Switch to the Aider buffer.
     - use "^" in the menu to toggle open aider session in other window inside current frame, or open a dedicate frame for aider session
 

--- a/aider.el
+++ b/aider.el
@@ -174,27 +174,27 @@ If not in a git repository, an error is raised."
               font-lock-keywords-case-fold-search source-keywords-case-fold-search)))))
 
 ;;;###autoload
-(defun aider-run-aider ()
-  "Create a comint-based buffer and run \"aider\" for interactive conversation."
-  (interactive)
+(defun aider-run-aider (&optional edit-args)
+  "Create a comint-based buffer and run \"aider\" for interactive conversation.
+With the universal argument, prompt to edit aider-args before running."
+  (interactive "P")
   (let* ((buffer-name (aider-buffer-name))
          (comint-terminfo-terminal "dumb")
-         (source-buffer (window-buffer (selected-window))))
+	 (current-args (if edit-args
+			   (split-string 
+			    (read-string "Edit aider arguments: "
+					 (mapconcat 'identity aider-args " ")))
+			 aider-args)))
+    ;; Check if the buffer already has a running process
     (unless (comint-check-proc buffer-name)
-      (apply 'make-comint-in-buffer "aider" buffer-name aider-program nil aider-args)
+      ;; Create a new comint buffer and start the process
+      (apply 'make-comint-in-buffer "aider" buffer-name aider-program nil current-args)
+      ;; Optionally, you can set the mode or add hooks here
       (with-current-buffer buffer-name
         (comint-mode)
-        (font-lock-add-keywords nil aider-font-lock-keywords t)
-        ;; Only inherit syntax highlighting when source buffer is in prog-mode
-        (when (with-current-buffer source-buffer
-                (derived-mode-p 'prog-mode))
-          (aider--inherit-source-highlighting source-buffer)
-          (font-lock-mode 1)
-          (font-lock-ensure)
-          (message "Aider buffer syntax highlighting inherited from %s"
-                   (with-current-buffer source-buffer major-mode)))
-        ))
-    (aider-switch-to-buffer)))
+        (font-lock-add-keywords nil aider-font-lock-keywords t)))
+    ;; Switch to the buffer
+    (pop-to-buffer buffer-name)))
 
 ;; Function to switch to the Aider buffer
 ;;;###autoload

--- a/aider.el
+++ b/aider.el
@@ -180,21 +180,26 @@ With the universal argument, prompt to edit aider-args before running."
   (interactive "P")
   (let* ((buffer-name (aider-buffer-name))
          (comint-terminfo-terminal "dumb")
-	 (current-args (if edit-args
-			   (split-string 
-			    (read-string "Edit aider arguments: "
+         (current-args (if edit-args
+                           (split-string
+                            (read-string "Edit aider arguments: "
 					 (mapconcat 'identity aider-args " ")))
-			 aider-args)))
-    ;; Check if the buffer already has a running process
+                         aider-args))
+         (source-buffer (window-buffer (selected-window))))
     (unless (comint-check-proc buffer-name)
-      ;; Create a new comint buffer and start the process
       (apply 'make-comint-in-buffer "aider" buffer-name aider-program nil current-args)
-      ;; Optionally, you can set the mode or add hooks here
       (with-current-buffer buffer-name
         (comint-mode)
-        (font-lock-add-keywords nil aider-font-lock-keywords t)))
-    ;; Switch to the buffer
-    (pop-to-buffer buffer-name)))
+        (font-lock-add-keywords nil aider-font-lock-keywords t)
+        ;; Only inherit syntax highlighting when source buffer is in prog-mode
+        (when (with-current-buffer source-buffer
+                (derived-mode-p 'prog-mode))
+          (aider--inherit-source-highlighting source-buffer)
+          (font-lock-mode 1)
+          (font-lock-ensure)
+          (message "Aider buffer syntax highlighting inherited from %s"
+                   (with-current-buffer source-buffer major-mode)))))
+    (aider-switch-to-buffer)))
 
 ;; Function to switch to the Aider buffer
 ;;;###autoload


### PR DESCRIPTION
This PR offers the user to use the universal argument to change the content of `aider-args` before running aider.

So they can use:
- `C-c a C-u a`
- `C-u M-x aider-run-aider`
- or `C-u` before any keybind you might have