### PR TITLE
Handle multi-line input in the aider buffer

### DIFF
--- a/aider.el
+++ b/aider.el
@@ -205,7 +205,7 @@ With the universal argument, prompt to edit aider-args before running."
       (apply 'make-comint-in-buffer "aider" buffer-name aider-program nil current-args)
       (with-current-buffer buffer-name
         (comint-mode)
-        (setq-local comint-input-sender 'aider-input-sender)
+        (setq-local comint-input-sender 'aider-input-sender) ;; this will only impact the prompt entered directly inside comint buffer. comint-send-string function won't be affected. so aider--process-message-if-multi-line won't be triggered twice.
         (font-lock-add-keywords nil aider-font-lock-keywords t)
         ;; Only inherit syntax highlighting when source buffer is in prog-mode
         (when (with-current-buffer source-buffer

--- a/aider.el
+++ b/aider.el
@@ -205,6 +205,7 @@ With the universal argument, prompt to edit aider-args before running."
       (apply 'make-comint-in-buffer "aider" buffer-name aider-program nil current-args)
       (with-current-buffer buffer-name
         (comint-mode)
+        (setq-local comint-input-sender 'aider-input-sender)
         (font-lock-add-keywords nil aider-font-lock-keywords t)
         ;; Only inherit syntax highlighting when source buffer is in prog-mode
         (when (with-current-buffer source-buffer
@@ -215,6 +216,10 @@ With the universal argument, prompt to edit aider-args before running."
           (message "Aider buffer syntax highlighting inherited from %s"
                    (with-current-buffer source-buffer major-mode)))))
     (aider-switch-to-buffer)))
+
+(defun aider-input-sender (proc string)
+  "Handle multi-line inputs being sent to Aider."
+  (comint-simple-send proc (aider--process-message-if-multi-line string)))
 
 ;; Function to switch to the Aider buffer
 ;;;###autoload


### PR DESCRIPTION
Currently, if you enter a multi-line prompt and try to send it, Aider will interpret it as multiple commands. We can ensure that multi-line inputs are always properly wrapped in begin/end tags.

See #51 