### PR TITLE
Don't try to byte-compile aider-doom.el

### DIFF
--- a/aider-doom.el
+++ b/aider-doom.el
@@ -1,4 +1,4 @@
-;;; aider-doom.el --- Description -*- lexical-binding: t; -*-
+;;; aider-doom.el --- Description -*- lexical-binding: t; no-byte-compile: t -*-
 ;;
 ;; This file is not part of GNU Emacs.
 ;;


### PR DESCRIPTION
Byte-compiling aider-doom.el fails unless Doom's `map!` macro is defined first. Doom defines this as part of its initialization, but it is not normally defined when byte-compiling: even when installing aider-doom.el using Doom, Doom byte-compiles packages in a separate process (without itself loaded) and is just ignoring the failure to byte-compile this file.

This does no harm when aider-doom.el is used by Doom, but can be an annoyance when packaging aider.el using something that fails on byte compilation failures by default (see
https://github.com/marienz/nix-doom-emacs-unstraightened/issues/50).

Since byte-compiling this file will (normally) fail anyway, explicitly disable it.