### PR TITLE
feat: Add helm feature check before overriding aider-read-string

### DIFF
--- a/aider-helm.el
+++ b/aider-helm.el
@@ -54,7 +54,8 @@ INITIAL-INPUT is optional initial input string."
 
 ;;;###autoload
 (with-eval-after-load 'aider
-  (defalias 'aider-read-string 'aider-helm-read-string))
+  (when (featurep 'helm)
+    (defalias 'aider-read-string 'aider-helm-read-string)))
 
 (provide 'aider-helm)
 ;;; aider-helm.el ends here

--- a/aider-helm.el
+++ b/aider-helm.el
@@ -54,8 +54,10 @@ INITIAL-INPUT is optional initial input string."
 
 ;;;###autoload
 (with-eval-after-load 'aider
-  (when (featurep 'helm)
-    (defalias 'aider-read-string 'aider-helm-read-string)))
+  (if (featurep 'helm)
+    (defalias 'aider-read-string 'aider-helm-read-string)
+    (message "Helm is not available. Please install helm package to use aider-helm features")
+    ))
 
 (provide 'aider-helm)
 ;;; aider-helm.el ends here


### PR DESCRIPTION
If helm is not installed, it was causing `aider-read-string` to be undefined breaking many of the functionality.

This checks if it is installed prior to overwriting

tested on Emacs v29.4