### PR TITLE
Fix: Handle the case when the current buffer file is not in a git repo

### DIFF
--- a/aider.el
+++ b/aider.el
@@ -183,9 +183,9 @@ If not in a git repository and no buffer file exists, an error is raised."
      ;; Case 2: Has buffer file (handles both nil and "fatal" git-repo-path cases)
      (current-file
       (format "*aider:%s*" 
-              (directory-file-name 
-               (file-name-directory 
-                (directory-file-name (file-name-directory current-file))))))
+              (file-name-directory
+               (directory-file-name
+                (file-name-directory current-file)))))
      ;; Case 3: No git repo and no buffer file
      (t
       (error "Not in a git repository and no buffer file available")))))

--- a/aider.el
+++ b/aider.el
@@ -175,12 +175,17 @@ If not in a git repository and no buffer file exists, an error is raised."
   (let ((git-repo-path (magit-toplevel))
         (current-file (buffer-file-name)))
     (cond
-     ;; Case 1: Valid git repo path
-     ((and git-repo-path (not (string-match-p "fatal" git-repo-path)))
+     ;; Case 1: Valid git repo path (not nil and not containing "fatal")
+     ((and git-repo-path 
+           (stringp git-repo-path)
+           (not (string-match-p "fatal" git-repo-path)))
       (format "*aider:%s*" git-repo-path))
-     ;; Case 2: Has buffer file
+     ;; Case 2: Has buffer file (handles both nil and "fatal" git-repo-path cases)
      (current-file
-      (format "*aider:%s*" (file-name-directory current-file)))
+      (format "*aider:%s*" 
+              (directory-file-name 
+               (file-name-directory 
+                (directory-file-name (file-name-directory current-file))))))
      ;; Case 3: No git repo and no buffer file
      (t
       (error "Not in a git repository and no buffer file available")))))

--- a/aider.el
+++ b/aider.el
@@ -183,12 +183,10 @@ If not in a git repository and no buffer file exists, an error is raised."
      ;; Case 2: Has buffer file (handles both nil and "fatal" git-repo-path cases)
      (current-file
       (format "*aider:%s*" 
-              (file-name-directory
-               (directory-file-name
-                (file-name-directory current-file)))))
+              (file-name-directory current-file)))
      ;; Case 3: No git repo and no buffer file
      (t
-      (error "Not in a git repository and no buffer file available")))))
+      (error "Not in a git repository and current buffer is not associated with a file")))))
 
 (defun aider--inherit-source-highlighting (source-buffer)
   "Inherit syntax highlighting settings from SOURCE-BUFFER."

--- a/aider.el
+++ b/aider.el
@@ -170,12 +170,20 @@ Affects the system message too.")
 ;; (global-set-key (kbd "C-c a") 'aider-transient-menu)
 
 (defun aider-buffer-name ()
-  "Generate the Aider buffer name based on the git repo of the current active buffer using a git command.
-If not in a git repository, an error is raised."
-  (let ((git-repo-path (magit-toplevel)))
-    (if (string-match-p "fatal" git-repo-path)
-        (error "Not in a git repository")
-      (format "*aider:%s*" git-repo-path))))
+  "Generate the Aider buffer name based on the git repo or current buffer file path.
+If not in a git repository and no buffer file exists, an error is raised."
+  (let ((git-repo-path (magit-toplevel))
+        (current-file (buffer-file-name)))
+    (cond
+     ;; Case 1: Valid git repo path
+     ((and git-repo-path (not (string-match-p "fatal" git-repo-path)))
+      (format "*aider:%s*" git-repo-path))
+     ;; Case 2: Has buffer file
+     (current-file
+      (format "*aider:%s*" (file-name-directory current-file)))
+     ;; Case 3: No git repo and no buffer file
+     (t
+      (error "Not in a git repository and no buffer file available")))))
 
 (defun aider--inherit-source-highlighting (source-buffer)
   "Inherit syntax highlighting settings from SOURCE-BUFFER."

--- a/test_aider.el
+++ b/test_aider.el
@@ -4,29 +4,30 @@
   "Test the aider-buffer-name function."
   ;; Test normal git repo case
   (cl-letf (((symbol-function 'magit-toplevel)
-             (lambda () "/path/to/git/repo")))
-    (should (equal (aider-buffer-name) "*aider:/path/to/git/repo*")))
+             (lambda () "/path/to/git/repo/")))
+    (should (equal (aider-buffer-name) "*aider:/path/to/git/repo/*")))
   
   ;; Test when magit-toplevel returns nil but buffer has a file
   (cl-letf (((symbol-function 'magit-toplevel)
              (lambda () nil))
             ((symbol-function 'buffer-file-name)
              (lambda () "/path/to/some/file.el")))
-    (should (equal (aider-buffer-name) "*aider:/path/to/some*")))
+    (should (equal (aider-buffer-name) "*aider:/path/to/some/*")))
 
   ;; Test when magit-toplevel returns fatal message but buffer has a file
   (cl-letf (((symbol-function 'magit-toplevel)
              (lambda () "fatal: not a git repository"))
             ((symbol-function 'buffer-file-name)
              (lambda () "/another/path/file.txt")))
-    (should (equal (aider-buffer-name) "*aider:/another/path*")))
+    (should (equal (aider-buffer-name) "*aider:/another/path/*")))
 
   ;; Test error case when not in git repo and no buffer file
   (cl-letf (((symbol-function 'magit-toplevel)
              (lambda () nil))
             ((symbol-function 'buffer-file-name)
              (lambda () nil)))
-    (should-error (aider-buffer-name) :type 'error)))
+    (should-error (aider-buffer-name) :type 'error))
+  )
 
 (ert-deftest aider--process-message-if-multi-line-test ()
   "Test the aider--process-message-if-multi-line function."


### PR DESCRIPTION
When current buffer file is not associated with a git repo, it should still be able to start the aider session with aider-run-aider.

Aider itself is able to do that and ask if we want to init the git for the dir.

![Screenshot from 2025-02-08 11-48-54](https://github.com/user-attachments/assets/4cb59182-e13f-458a-b989-3960a2a8cd69)
