### PR TITLE
Feat: Move programming language syntax color rendering from aider-run-aider to aider-switch-to-buffer

### DIFF
--- a/README.org
+++ b/README.org
@@ -47,7 +47,7 @@ If you have Straight installed
     :straight (:host github :repo "tninja/aider.el" :files ("aider.el"))
     :config
     ;; For claude-3-5-sonnet
-    (setq aider-args '("--model" "anthropic/claude-3-5-sonnet-20241022"))
+    (setq aider-args '("--model" "sonnet"))
     (setenv "ANTHROPIC_API_KEY" anthropic-api-key)
     ;; Or chatgpt model
     ;; (setq aider-args '("--model" "o3-mini"))

--- a/README.org
+++ b/README.org
@@ -27,7 +27,7 @@
   - Some work-around for code color was applied, but we still don't have a fundamental solution for this right now. Vterm is good but I don't want to depend on it at this moment.
   - Would be great if someone can solve this problem, or make it better without introduce too many complexity.
 
-- *There is no advantage interacting with aider through this comint terminal.* But the comint terminal is well integrated with other parts of emacs, it is encouraged to generate and send prompt to it, either from:
+- *There is no advantage interacting with aider through this comint terminal directly.* Instead, since the comint terminal is well integrated with other parts of emacs, it is encouraged to generate and send prompt to it, either from:
   - Code buffer directly by _aider code change related commands_ or _ask question related commands_. It make less context switching, and it help building up prompt, reducing manual typing.
   - Aider prompt file (~aider-open-prompt-file~, ~C-c a p~). This is the traditional way in emacs to communicate with comint buffer (just like ESS, python-mode, scala-mode, etc). It is easy to revisit your used commands, organize large code change into several small prompts, and it is easy for multi-line prompts
 
@@ -114,6 +114,8 @@ You can have helm-based completion with run the following code, after install he
 - Use ~C-c a p~ to open the repo specific prompt file. You can use this file to organize tasks, and write prompt and send them to the Aider session. multi-line prompts are supported.
 
 - People happy with sending code from editor buffer to comint buffer (eg. ESS, python-mode, scala-mode) might like this. This is a interactive and reproducible way
+
+- ~C-c C-n~ key can be used to send the current prompt line to the comint buffer. Or batch send selected region line by line. To my experience, this is the most used method in aider prompt file.
 
 - The following example shows ~C-c C-c~ key pressed when cursor is on the prompt.
 

--- a/aider.el
+++ b/aider.el
@@ -234,11 +234,16 @@ If the current buffer is already the Aider buffer, do nothing."
   (interactive)
   (if (string= (buffer-name) (aider-buffer-name))
       (message "Already in Aider buffer")
-    (if-let ((buffer (get-buffer (aider-buffer-name))))
-        (if aider--switch-to-buffer-other-frame
-            (switch-to-buffer-other-frame buffer)
-          (pop-to-buffer buffer))
-      (message "Aider buffer '%s' does not exist." (aider-buffer-name)))))
+    (let ((source-buffer (current-buffer)))
+      (if-let ((buffer (get-buffer (aider-buffer-name))))
+          (progn
+            (if aider--switch-to-buffer-other-frame
+                (switch-to-buffer-other-frame buffer)
+              (pop-to-buffer buffer))
+            (when (with-current-buffer source-buffer
+                    (derived-mode-p 'prog-mode))
+              (aider--inherit-source-highlighting source-buffer)))
+        (message "Aider buffer '%s' does not exist." (aider-buffer-name))))))
 
 
 ;; Add a function, aider-clear-buffer. It will switch aider buffer and call comint-clear-buffer

--- a/aider.el
+++ b/aider.el
@@ -189,7 +189,12 @@ If not in a git repository and no buffer file exists, an error is raised."
                   ,source-keywords-case-fold-search)))
         (setq font-lock-keywords source-keywords
               font-lock-keywords-only source-keywords-only
-              font-lock-keywords-case-fold-search source-keywords-case-fold-search)))))
+              font-lock-keywords-case-fold-search source-keywords-case-fold-search)
+        (font-lock-mode 1)
+        (font-lock-ensure)
+        (message "Aider buffer syntax highlighting inherited from %s"
+                 (with-current-buffer source-buffer major-mode))
+        ))))
 
 ;;;###autoload
 (defun aider-run-aider (&optional edit-args)
@@ -213,11 +218,7 @@ With the universal argument, prompt to edit aider-args before running."
         ;; Only inherit syntax highlighting when source buffer is in prog-mode
         (when (with-current-buffer source-buffer
                 (derived-mode-p 'prog-mode))
-          (aider--inherit-source-highlighting source-buffer)
-          (font-lock-mode 1)
-          (font-lock-ensure)
-          (message "Aider buffer syntax highlighting inherited from %s"
-                   (with-current-buffer source-buffer major-mode)))))
+          (aider--inherit-source-highlighting source-buffer))))
     (aider-switch-to-buffer)))
 
 (defun aider-input-sender (proc string)

--- a/aider.el
+++ b/aider.el
@@ -208,7 +208,7 @@ With the universal argument, prompt to edit aider-args before running."
                             (read-string "Edit aider arguments: "
                                          (mapconcat 'identity aider-args " ")))
                          aider-args))
-         (source-buffer (window-buffer (selected-window))))
+         (source-buffer (current-buffer)))
     (unless (comint-check-proc buffer-name)
       (apply 'make-comint-in-buffer "aider" buffer-name aider-program nil current-args)
       (with-current-buffer buffer-name

--- a/aider.el
+++ b/aider.el
@@ -207,18 +207,13 @@ With the universal argument, prompt to edit aider-args before running."
                            (split-string
                             (read-string "Edit aider arguments: "
                                          (mapconcat 'identity aider-args " ")))
-                         aider-args))
-         (source-buffer (current-buffer)))
+                         aider-args)))
     (unless (comint-check-proc buffer-name)
       (apply 'make-comint-in-buffer "aider" buffer-name aider-program nil current-args)
       (with-current-buffer buffer-name
         (comint-mode)
-        (setq-local comint-input-sender 'aider-input-sender) ;; this will only impact the prompt entered directly inside comint buffer. comint-send-string function won't be affected. so aider--process-message-if-multi-line won't be triggered twice.
-        (font-lock-add-keywords nil aider-font-lock-keywords t)
-        ;; Only inherit syntax highlighting when source buffer is in prog-mode
-        (when (with-current-buffer source-buffer
-                (derived-mode-p 'prog-mode))
-          (aider--inherit-source-highlighting source-buffer))))
+        (setq-local comint-input-sender 'aider-input-sender)
+        (font-lock-add-keywords nil aider-font-lock-keywords t)))
     (aider-switch-to-buffer)))
 
 (defun aider-input-sender (proc string)


### PR DESCRIPTION
So that the programming language syntax color will match the most recently aider.el used source code, no need to restart aider session.

Also tweaked some text