### PR TITLE
Fix: C-c C-c in other org buffer doesn't work as expected. it also point to aider-send-block-or-region

### DIFF
--- a/README.org
+++ b/README.org
@@ -46,7 +46,7 @@ If you have Straight installed
   (use-package aider
     :straight (:host github :repo "tninja/aider.el" :files ("aider.el"))
     :config
-    ;; For claude-3-5-sonnet
+    ;; For latest claude sonnet model
     (setq aider-args '("--model" "sonnet"))
     (setenv "ANTHROPIC_API_KEY" anthropic-api-key)
     ;; Or chatgpt model

--- a/aider-etc.el
+++ b/aider-etc.el
@@ -19,3 +19,17 @@
         (message "The current buffer is not in a Git repository.")
       (let ((repo-path (string-trim git-repo-path)))
         (dired-other-window repo-path)))))
+
+;; New function to explain the symbol at line
+;;;###autoload
+(defun aider-explain-symbol-under-point ()
+  "Ask Aider to explain symbol under point, given the code line as background info."
+  (interactive)
+  (let* ((symbol (thing-at-point 'symbol))
+         (line (buffer-substring-no-properties
+                (line-beginning-position)
+                (line-end-position)))
+         (question (format "Please explain what '%s' means in the context of this code line: %s"
+                         symbol line)))
+    (aider-current-file-command-and-switch "/ask " question)
+    ))

--- a/aider.el
+++ b/aider.el
@@ -858,11 +858,6 @@ If file doesn't exist, create it with command binding help and sample prompt."
     map)
   "Keymap for Aider Minor Mode.")
 
-(add-hook 'org-mode-hook
-          (lambda ()
-            (when aider-minor-mode
-              (define-key (current-local-map) (kbd "C-c C-c") 'aider-send-block-or-region))))
-
 ;; Define the Aider Minor Mode
 ;;;###autoload
 (define-minor-mode aider-minor-mode
@@ -876,7 +871,11 @@ If file doesn't exist, create it with command binding help and sample prompt."
             (when (and (buffer-file-name)
                        (string= aider-prompt-file-name (file-name-nondirectory (buffer-file-name))))
               (aider-minor-mode 1)
-              (define-key (current-local-map) (kbd "C-c C-c") 'aider-send-block-or-region)
+              (let ((map (make-sparse-keymap)))
+                (define-key map (kbd "C-c C-c") 'aider-send-block-or-region)
+                (setq-local minor-mode-overriding-map-alist
+                            (cons (cons 'aider-minor-mode map)
+                                  (assq-delete-all 'aider-minor-mode minor-mode-overriding-map-alist))))
               )))
 
 (when (featurep 'doom)

--- a/aider.el
+++ b/aider.el
@@ -117,7 +117,7 @@ This function can be customized or redefined by the user."
     (aider--infix-switch-to-buffer-other-frame)
     ("a" "Run Aider (C-u: args) " aider-run-aider)
     ("z" "Switch to Aider Buffer" aider-switch-to-buffer)
-    ("o" "Select Model" aider-change-model)
+    ("o" "Select Model (C-u: leadboard)" aider-change-model)
     ("s" "Reset Aider (C-u: clear)" aider-reset)
     ("l" "Other Command (C-u: manual)" aider-other-process-command)
     ("x" "Exit Aider" aider-exit)
@@ -766,11 +766,11 @@ Otherwise implement TODOs for the entire current file."
 
 ;;; Model selection functions
 ;;;###autoload
-(defun aider-change-model ()
+(defun aider-change-model (leaderboards)
   "Interactively select and change AI model in current aider session.
 With prefix argument (C-u), open the Aider LLM leaderboard in a browser."
   (interactive "P")
-  (if universal-argument
+  (if leaderboards
       (browse-url "https://aider.chat/docs/leaderboards/")
     (let ((model (aider--select-model)))
       (when model

--- a/aider.el
+++ b/aider.el
@@ -39,8 +39,8 @@ When nil, use standard `display-buffer' behavior."
   :group 'aider)
 
 (defcustom aider-popular-models '("sonnet"  ;; really good in practical
-                                  "o3-mini" ;; very powerful
-                                  "gemini/gemini-exp-1206"  ;; free
+                                  "o3-mini" ;; very powerful. good for difficult task
+                                  "gemini-2.0-flash-exp"  ;; free
                                   "r1"  ;; performance match o1, price << claude sonnet. weakness: small context
                                   "deepseek/deepseek-chat"  ;; chatgpt-4o level performance, price is 1/100. weakness: small context
                                   )
@@ -771,7 +771,8 @@ Otherwise implement TODOs for the entire current file."
   (interactive)
   (let ((model (aider--select-model)))
     (when model
-      (aider--send-command (format "/model %s" model) t))))
+      (aider--send-command (format "/model %s" model) t)
+      (message "Model changed to %s, check https://aider.chat/docs/leaderboards/ for the benchmark" model))))
 
 (defun aider--select-model ()
   "Private function for model selection with completion."

--- a/aider.el
+++ b/aider.el
@@ -767,12 +767,15 @@ Otherwise implement TODOs for the entire current file."
 ;;; Model selection functions
 ;;;###autoload
 (defun aider-change-model ()
-  "Interactively select and change AI model in current aider session."
-  (interactive)
-  (let ((model (aider--select-model)))
-    (when model
-      (aider--send-command (format "/model %s" model) t)
-      (message "Model changed to %s, customize aider-popular-models for the model candidates" model))))
+  "Interactively select and change AI model in current aider session.
+With prefix argument (C-u), open the Aider LLM leaderboard in a browser."
+  (interactive "P")
+  (if universal-argument
+      (browse-url "https://aider.chat/docs/leaderboards/")
+    (let ((model (aider--select-model)))
+      (when model
+        (aider--send-command (format "/model %s" model) t)
+        (message "Model changed to %s, customize aider-popular-models for the model candidates" model)))))
 
 (defun aider--select-model ()
   "Private function for model selection with completion."

--- a/aider.el
+++ b/aider.el
@@ -703,7 +703,7 @@ Otherwise:
                          (file-name-nondirectory buffer-file-name) common-instructions)))
                (user-command (aider-read-string "Unit test generation instruction: " initial-input)))
           (aider-current-file-command-and-switch "/architect " user-command))
-          ))))))
+          )))))
 
 ;;;###autoload
 (defun aider-fix-failing-test-under-cursor ()

--- a/aider.el
+++ b/aider.el
@@ -772,7 +772,7 @@ Otherwise implement TODOs for the entire current file."
   (let ((model (aider--select-model)))
     (when model
       (aider--send-command (format "/model %s" model) t)
-      (message "Model changed to %s, check https://aider.chat/docs/leaderboards/ for the benchmark" model))))
+      (message "Model changed to %s, customize aider-popular-models for the model candidates" model))))
 
 (defun aider--select-model ()
   "Private function for model selection with completion."

--- a/aider.el
+++ b/aider.el
@@ -406,7 +406,7 @@ COMMAND should be a string representing the command to send."
   "Prompt the user for a command and send it to the corresponding aider comint buffer prefixed with \"/code \"."
   (interactive)
   (let ((command (aider-read-string "Enter code change requirement: ")))
-    (aider-send-command-with-prefix "/code " command)))
+    (aider-current-file-command-and-switch "/code " command)))
 
 ;; New function to get command from user and send it prefixed with "/ask "
 ;;;###autoload
@@ -430,11 +430,11 @@ If cursor is inside a function, include the function name as context."
                        raw-question))
            (region-text (and (region-active-p) 
                              (buffer-substring-no-properties (region-beginning) (region-end))))
-           (command (if region-text
-                        (format "/ask %s: %s" question region-text)
-                      (format "/ask %s" question))))
-      (aider-add-current-file)
-      (aider--send-command command t))))
+           (question-context (if region-text
+                                 (format "%s: %s" question region-text)
+                               question)))
+      (aider-current-file-command-and-switch "/ask " question-context)
+      )))
 
 ;;;###autoload
 (defun aider-general-question ()
@@ -452,7 +452,7 @@ If cursor is inside a function, include the function name as context."
   (if homepage
       (aider-open-aider-home) 
     (let ((command (aider-read-string "Enter help question: ")))
-      (aider-send-command-with-prefix "/help " command))
+      (aider-current-file-command-and-switch "/help " command))
       ))
 
 ;;;###autoload
@@ -467,7 +467,7 @@ If cursor is inside a function, include the function name as context."
   "Prompt the user for a command and send it to the corresponding aider comint buffer prefixed with \"/architect \"."
   (interactive)
   (let ((command (aider-read-string "Enter architect discussion question: ")))
-    (aider-send-command-with-prefix "/architect " command)))
+    (aider-current-file-command-and-switch "/architect " command)))
 
 ;; New function to get command from user and send it prefixed with "/ask ", might be tough for AI at this moment
 ;;;###autoload
@@ -522,8 +522,7 @@ for the specified function."
              (prompt (format "Instruction to %s" prefix))
              (instruction (aider-read-string prompt))
              (command (format "/architect %s%s" prefix instruction)))
-        (aider-add-current-file)
-        (aider--send-command command t))
+        (aider-current-file-command-and-switch "/architect " (concat prefix instruction)))
     (message "No function found at cursor position.")))
 
 ;;;###autoload
@@ -579,8 +578,7 @@ Prompts user for specific questions about the function."
              (prompt (format "Enter your question to %s" prefix))
              (user-question (aider-read-string prompt))
              (command (format "/ask %s%s" prefix user-question)))
-        (aider-add-current-file)
-        (aider--send-command command t))
+        (aider-current-file-command-and-switch "/ask " (concat prefix user-question)))
     (message "No function found at cursor position.")))
 
 ;;;###autoload
@@ -591,21 +589,7 @@ Prompts user for specific questions about the function."
       (aider-region-explain)
     (aider-function-explain)))
 
-;; New function to explain the symbol at line
-;;;###autoload
-(defun aider-explain-symbol-under-point ()
-  "Ask Aider to explain symbol under point, given the code line as background info."
-  (interactive)
-  (let* ((symbol (thing-at-point 'symbol))
-         (line (buffer-substring-no-properties
-                (line-beginning-position)
-                (line-end-position)))
-         (prompt (format "/ask Please explain what '%s' means in the context of this code line: %s"
-                         symbol line)))
-    (aider-add-current-file)
-    (aider--send-command prompt t)))
-
-(defun aider-send-command-with-prefix (prefix command)
+(defun aider-current-file-command-and-switch (prefix command)
   "Send COMMAND to the Aider buffer prefixed with PREFIX."
   (aider-add-current-file)
   (aider--send-command (concat prefix command) t))
@@ -704,10 +688,8 @@ Otherwise:
                 (let* ((initial-input 
                        (format "Please implement test function '%s'. Follow standard unit testing practices and make it a meaningful test. Do not use Mock if possible." 
                               function-name))
-                      (user-command (aider-read-string "Test implementation instruction: " initial-input))
-                      (command (format "/architect %s" user-command)))
-                  (aider-add-current-file)
-                  (aider--send-command command t))
+                      (user-command (aider-read-string "Test implementation instruction: " initial-input)))
+                  (aider-current-file-command-and-switch "/architect " user-command))
               (message "Current function '%s' does not appear to be a test function." function-name))
           (message "Please place cursor inside a test function to implement.")))
        ;; Non-test file case
@@ -719,10 +701,9 @@ Otherwise:
                            function-name common-instructions)
                   (format "Please write unit test code for file '%s'. For each function %s" 
                          (file-name-nondirectory buffer-file-name) common-instructions)))
-               (user-command (aider-read-string "Unit test generation instruction: " initial-input))
-               (command (format "/architect %s" user-command)))
-          (aider-add-current-file)
-          (aider--send-command command t)))))))
+               (user-command (aider-read-string "Unit test generation instruction: " initial-input)))
+          (aider-current-file-command-and-switch "/architect " user-command))
+          ))))))
 
 ;;;###autoload
 (defun aider-fix-failing-test-under-cursor ()
@@ -734,8 +715,7 @@ This function assumes the cursor is on or inside a test function."
                                    test-function-name))
              (test-output (aider-read-string "Architect question: " initial-input))
              (command (format "/architect %s" test-output)))
-        (aider-add-current-file)
-        (aider--send-command command t))
+        (aider-current-file-command-and-switch "/architect " test-output))
     (message "No test function found at cursor position.")))
 
 (defun aider--is-comment-line (line)
@@ -782,8 +762,7 @@ Otherwise implement TODOs for the entire current file."
                       (file-name-nondirectory buffer-file-name)))))
            (user-command (aider-read-string "TODO implementation instruction: " initial-input))
            (command (format "/architect %s" user-command)))
-      (aider-add-current-file)
-      (aider--send-command command t))))
+      (aider-current-file-command-and-switch "/architect " user-command))))
 
 ;;; Model selection functions
 ;;;###autoload


### PR DESCRIPTION
Also did some refactoring:

1. use aider-current-file-command-and-switch function when possible for simplification
2. move unused function to aider-etc.el (aider-explain-symbol-under-point)
3. add C-u and message to aider-change-model about how to config