### PR TITLE
Feat: Add magit rebase style file operation in aider-prompt-mode, and send block line by line command

### DIFF
--- a/README.org
+++ b/README.org
@@ -52,6 +52,14 @@
   - Code buffer directly by _aider code change related commands_ or _ask question related commands_. It make less context switching, and it help building up prompt, reducing manual typing.
   - Aider prompt file (~aider-open-prompt-file~, ~C-c a p~). This is the traditional way in emacs to communicate with comint buffer (just like ESS, python-mode, scala-mode, etc). It is easy to revisit your used commands, organize and manage large code change requiring more prompts and break them into sub-tasks (cause it is org), and it is easy for multi-line prompts. Recently, syntax highlight, completion and snippets were added to this file, and it is now a good place to write and organize your prompts.
 
+** Alternatives to aidermacs
+
+- More Focus on build prompts using your code (buffer/selection).
+- Search/reuse prompts easily with helm.
+- More Focus on code quality (Code Review, TDD + AI).
+- Organize project with repo specific Aider prompt file
+- Snippets for community prompts.
+
 * Installation
 
 - Emacs need to be >= 26.1

--- a/aider-core.el
+++ b/aider-core.el
@@ -231,12 +231,12 @@ of common commands such as \"/add\", \"/ask\", \"/drop\", etc."
       (when (string-match "^/\\(\\w*\\)" line-str)
         (let* ((beg (+ line-start (match-beginning 0)))
                (end (+ line-start (match-end 0)))
-               (commands '("/add" "/read-only" "/architect" "/ask" "/copy" "/copy-context"
-                           "/drop" "/paste" "/help" "/chat-mode" "/diff" "/editor" "/git"
+               (commands '("/add" "/architect" "/ask" "/code" "/reset" "/undo" "/lint" "/read-only"
+                           "/drop" "/copy" "/copy-context" "/clear" "/commit" "/exit" "/quit"
+                           "/paste" "/help" "/chat-mode" "/diff" "/editor" "/git"
                            "/load" "/ls" "/map" "/map-refresh" "/model" "/models"
                            "/multiline-mode" "/report" "/run" "/save" "/settings" "/test"
-                           "/tokens" "/voice" "/web"
-                           "/clear" "/code" "/commit" "/exit" "/quit" "/reset" "/undo" "/lint"))
+                           "/tokens" "/voice" "/web"))
                (prefix (match-string 0 line-str))
                (candidates (seq-filter (lambda (cmd)
                                          (string-prefix-p prefix cmd))

--- a/aider.el
+++ b/aider.el
@@ -62,7 +62,7 @@ Also based on aider LLM benchmark: https://aider.chat/docs/leaderboards/"
     ("p" "Input with Repo Prompt File" aider-open-prompt-file)
     ("o" "Select Model (C-u: leadboard)" aider-change-model)
     ("s" "Reset Aider (C-u: clear)" aider-reset)
-    ("l" "Other Command (C-u: manual)" aider-other-process-command)
+    ("l" "Other Command" aider-other-process-command)
     ]
    ["File Operation"
     ("f" "Add Current / Marked File (C-u: readonly)" aider-add-current-file-or-dired-marked-files)
@@ -84,7 +84,6 @@ Also based on aider LLM benchmark: https://aider.chat/docs/leaderboards/"
    ["Discussion"
     ("q" "Question on Function / Region" aider-ask-question)
     ("y" "Then Go Ahead" aider-go-ahead)
-    ;; ("e" "Explain Function / Region" aider-function-or-region-explain)
     ("Q" "Question without Context" aider-general-question)
     ("D" "Debug Exception" aider-debug-exception)
     ("h" "Help (C-u: homepage)" aider-help)
@@ -120,7 +119,7 @@ With prefix argument CLEAR, clear the buffer contents instead of just resetting.
   (aider--send-command "/exit"))
 
 ;;;###autoload
-(defun aider-other-process-command (&optional manual)
+(defun aider-other-process-command ()
   "Send process control commands to aider.
 With prefix argument MANUAL, manually enter the command
 Prompts user to select from a list of available commands:
@@ -134,12 +133,12 @@ Prompts user to select from a list of available commands:
 - /paste: Paste the last copied chat message
 - /settings: Show current settings
 - /tokens: Show token usage"
-  (interactive "P")
-  (if manual
-      (aider-general-command)
-    (let* ((commands '("/clear" "/copy" "/drop" "/ls" "/lint" "/map"
-                       "/map-refresh" "/paste" "/settings" "/tokens"))
-           (command (completing-read "Select command: " commands nil t)))
+  (interactive)
+  (let* ((commands '("manual input" "/clear" "/copy" "/drop" "/ls" "/lint" "/map"
+                     "/map-refresh" "/paste" "/settings" "/tokens"))
+         (command (completing-read "Select command: " commands nil t)))
+    (if (string= command "manual input")
+        (aider-general-command)
       (aider--send-command command t))))
 
 ;; Function to send a custom command to corresponding aider buffer

--- a/aider.el
+++ b/aider.el
@@ -8,8 +8,24 @@
 ;; SPDX-License-Identifier: Apache-2.0
 
 ;;; Commentary:
-;; This package provides an interactive interface
-;; to communicate with https://github.com/paul-gauthier/aider.
+;; Tired of coding alone? This package + Aider (https://aider.chat/)
+;; brings an AI pair programmer *inside* Emacs! Aider works seamlessly
+;; with both *new* and *existing* codebases in your local Git repo,
+;; using AI models (Claude, ChatGPT, even local ones!) to help you. It
+;; can suggest improvements, squash bugs, or even write whole new
+;; sections of code. Boost your coding with AI, without ever leaving
+;; your Emacs comfort zone.
+;;
+;; In-editor Aider experience:
+;; - Manages Aider sessions per Git repo.
+;; - Menu for AI-assisted coding
+;;
+;; Alternatives to aidermacs:
+;; - More Focus on build prompts using your code (buffer/selection).
+;; - Search/reuse prompts easily with helm.
+;; - More Focus on code quality (Code Review, TDD + AI).
+;; - Organize project with repo specific Aider prompt file
+;; - Snippets for community prompts.
 
 ;;; Code:
 


### PR DESCRIPTION
The key C-c C-y will put /add to the line the cursor located, if there is no command ahead; otherwise, it will cycle through /add, /read-only, /drop. 

![Screenshot from 2025-03-17 20-04-37](https://github.com/user-attachments/assets/dd781b3e-ea40-4625-8d19-d1ba0590868e)

After we are happy about it, use C-c C-b to send these file command one by one to aider session.

The PR also improve the git diff file generation. Now it can pull change for a given commit sha.

