### PR TITLE
Feat: aider-helm-read-string-with-history accept candidate prompt list

### DIFF
--- a/aider-code-change.el
+++ b/aider-code-change.el
@@ -58,11 +58,10 @@ Otherwise, refactor the function under cursor."
                           "Optimize this code for better performance"
                           "Improve error handling and edge cases"
                           "Refactor to reduce complexity and improve readability"
+                          "Refactor this test, using better testing patterns, reducing duplication, and improving readability and maintainability. Maintain the current functionality of the tests."
                           "Make this code more maintainable and easier to test"
                           "Fix potential bugs or issues in this code"
-                          "Improve variable names and add clarifying comments"
-                          "Refactor to follow best practices for this language"
-                          "Convert to use more modern language features"))
+                          "Improve variable names and add clarifying comments"))
          (instruction (aider-read-string prompt nil candidate-list))
          (region-text (and region-active
                            (buffer-substring-no-properties (region-beginning) (region-end)))))

--- a/aider-code-change.el
+++ b/aider-code-change.el
@@ -40,39 +40,47 @@ REGION-TEXT, FUNCTION-NAME, and USER-COMMAND."
               user-command processed-region-text))))
 
 ;;;###autoload
-(defun aider-function-refactor ()
-  "Get the function name under cursor and send refactor command to aider.
-The command will be formatted as \"/architect\"
-followed by refactoring instructions for the specified function."
-  (interactive)
-  (if-let ((function-name (which-function)))
-      (let* ((prefix (format "refactor %s: " function-name))
-             (prompt (format "Instruction to %s" prefix))
-             (instruction (aider-read-string prompt)))
-        (aider-current-file-command-and-switch "/architect " (concat prefix instruction)))
-    (message "No function found at cursor position.")))
-
-;;;###autoload
-(defun aider-region-refactor ()
-  "Refactor the selected region of code."
-  (interactive)
-  (if (use-region-p)
-      (let* ((region-text (buffer-substring-no-properties (region-beginning) (region-end)))
-             (function-name (which-function))
-             (user-command (aider-read-string "Refactor instruction for selected region: "))
-             (command (aider-region-refactor-generate-command region-text function-name user-command)))
-        (aider-add-current-file)
-        (aider--send-command command t))
-    (message "No region selected.")))
-
-;;;###autoload
 (defun aider-function-or-region-refactor ()
-  "Call `aider-function-refactor` when no region is selected.
-Otherwise call `aider-region-refactor`."
+  "Refactor code under cursor or in selected region.
+If a region is selected, refactor that specific region.
+Otherwise, refactor the function under cursor."
   (interactive)
-  (if (region-active-p)
-      (aider-region-refactor)
-    (aider-function-refactor)))
+  (let* ((function-name (which-function))
+         (region-active (region-active-p))
+         (region-in-function (and region-active function-name))
+         (prompt (cond
+                  (region-in-function (format "Refactor instruction for selected region in function '%s': " function-name))
+                  (function-name (format "Refactor %s: " function-name))
+                  (region-active "Refactor instruction for selected region: ")
+                  (t "Refactor instruction: ")))
+         (candidate-list '("Simplify this code while preserving functionality"
+                          "Extract this logic into a separate helper function"
+                          "Optimize this code for better performance"
+                          "Improve error handling and edge cases"
+                          "Refactor to reduce complexity and improve readability"
+                          "Make this code more maintainable and easier to test"
+                          "Fix potential bugs or issues in this code"
+                          "Improve variable names and add clarifying comments"
+                          "Refactor to follow best practices for this language"
+                          "Convert to use more modern language features"))
+         (instruction (aider-read-string prompt nil candidate-list))
+         (region-text (and region-active
+                           (buffer-substring-no-properties (region-beginning) (region-end)))))
+    (cond
+     ;; Region selected case
+     (region-active
+      (let ((command (aider-region-refactor-generate-command
+                      region-text function-name instruction)))
+        (aider-add-current-file)
+        (aider--send-command command t)))
+     ;; Function case
+     (function-name
+      (aider-current-file-command-and-switch
+       "/architect "
+       (concat (format "refactor %s: " function-name) instruction)))
+     ;; Fallback case
+     (t (message "No function or region selected."))))
+  (message "Refactoring request sent to Aider"))
 
 (defun aider--is-comment-line (line)
   "Check if LINE is a comment line based on current buffer's comment syntax.

--- a/aider-core.el
+++ b/aider-core.el
@@ -91,7 +91,7 @@ Inherits from `comint-mode' with some Aider-specific customizations.
     (evil-define-key* 'normal aider-comint-mode-map (kbd "SPC") #'aider-core-insert-prompt)))
 
 ;;;###autoload
-(defun aider-plain-read-string (prompt &optional initial-input)
+(defun aider-plain-read-string (prompt &optional initial-input candidate-list)
   "Read a string from the user with PROMPT and optional INITIAL-INPUT.
 This function can be customized or redefined by the user."
   ;; it will persist the read-string history across Emacs sessions with aider-read-string-history

--- a/aider-discussion.el
+++ b/aider-discussion.el
@@ -16,9 +16,8 @@
 ;; New function to get command from user and send it prefixed with "/ask "
 ;;;###autoload
 (defun aider-ask-question ()
-  "Ask aider question.
-If NO-CONTEXT is non-nil, send the question to the general aider comint buffer.
-Otherwise, send the question to the corresponding aider comint buffer."
+  "Ask aider question about specific code.
+Focuses on understanding, analyzing, and improving the selected code or function."
   (interactive)
   ;; Dispatch to general question if in aider buffer
   (let* ((function-name (which-function))
@@ -29,7 +28,18 @@ Otherwise, send the question to the corresponding aider comint buffer."
                   (function-name (format "About function '%s': " function-name))
                   (region-active "Question for the selected region: ")
                   (t "Question: ")))
-         (raw-question (aider-read-string prompt))
+         ;; 重新设计的候选提示，更专注于代码理解和分析
+         (candidate-list '("What does this code do?"
+                          "Explain the logic of this code step by step"
+                          "What are the inputs and outputs of this code?"
+                          "Are there any edge cases not handled in this code?"
+                          "How could this code be simplified?"
+                          "What's the time/space complexity of this algorithm?"
+                          "Is there a more efficient way to implement this?"
+                          "What design patterns are used here?"
+                          "How does this code handle errors?"
+                          "What assumptions does this code make?"))
+         (raw-question (aider-read-string prompt nil candidate-list))
          (question (if function-name
                        (concat prompt raw-question)
                      raw-question))
@@ -39,7 +49,7 @@ Otherwise, send the question to the corresponding aider comint buffer."
                                (format "%s: %s" question region-text)
                              question)))
     (aider-current-file-command-and-switch "/ask " question-context)
-    (message "Ask aider to: explain code, review implementation, suggest improvements, or any other coding assistance")))
+    (message "Question about code sent to Aider")))
 
 ;;;###autoload
 (defun aider-general-question ()

--- a/aider-discussion.el
+++ b/aider-discussion.el
@@ -17,7 +17,7 @@
 ;;;###autoload
 (defun aider-ask-question ()
   "Ask aider question about specific code.
-Focuses on understanding, analyzing, and improving the selected code or function."
+Focuses on understanding, analyzing, improving the selected code or function."
   (interactive)
   ;; Dispatch to general question if in aider buffer
   (let* ((function-name (which-function))

--- a/aider-discussion.el
+++ b/aider-discussion.el
@@ -28,16 +28,15 @@ Focuses on understanding, analyzing, improving the selected code or function."
                   (function-name (format "About function '%s': " function-name))
                   (region-active "Question for the selected region: ")
                   (t "Question: ")))
-         (candidate-list '("What does this code do?"
-                          "Explain the logic of this code step by step"
+         (candidate-list '("What is your suggestion on the most important thing to do"
+                          "What does this code do? Explain the logic of this code step by step"
                           "What are the inputs and outputs of this code?"
                           "Are there any edge cases not handled in this code?"
                           "How could this code be simplified?"
                           "What's the time/space complexity of this algorithm?"
                           "Is there a more efficient way to implement this?"
                           "What design patterns are used here?"
-                          "How does this code handle errors?"
-                          "What assumptions does this code make?"))
+                          "How does this code handle errors?"))
          (raw-question (aider-read-string prompt nil candidate-list))
          (question (if function-name
                        (concat prompt raw-question)
@@ -54,7 +53,16 @@ Focuses on understanding, analyzing, improving the selected code or function."
 (defun aider-general-question ()
   "Ask aider question without context."
   (interactive)
-  (let ((question (aider-read-string "Enter general question to ask: ")))
+  (let* ((candidate-list '("Explain the purpose and functionality of these files"
+                          "What are the key functions/methods in these files?"
+                          "What is your suggestion on the most important thing to do in these files?"
+                          "Identify potential bugs or issues in these files"
+                          "What design patterns are used in these files?"
+                          "How could we optimize the performance of this code?"
+                          "Are there any security concerns in these files?"
+                          "How could we make this code more maintainable?"
+                          "Explain the overall architecture of this codebase"))
+         (question (aider-read-string "Enter general question to ask: " nil candidate-list)))
     (let ((command (format "/ask %s" question)))
       (aider--send-command command t))))
 

--- a/aider-discussion.el
+++ b/aider-discussion.el
@@ -28,7 +28,6 @@ Focuses on understanding, analyzing, and improving the selected code or function
                   (function-name (format "About function '%s': " function-name))
                   (region-active "Question for the selected region: ")
                   (t "Question: ")))
-         ;; 重新设计的候选提示，更专注于代码理解和分析
          (candidate-list '("What does this code do?"
                           "Explain the logic of this code step by step"
                           "What are the inputs and outputs of this code?"
@@ -64,47 +63,6 @@ Focuses on understanding, analyzing, and improving the selected code or function
   "Send the command \"go ahead\" to the corresponding aider comint buffer."
   (interactive)
   (aider--send-command "go ahead" t))
-
-;; New function to explain the code in the selected region
-;;;###autoload
-(defun aider-region-explain ()
-  "Ask Aider to explain the selected region of code."
-  (interactive)
-  (if (use-region-p)
-      (let* ((region-text (buffer-substring-no-properties (region-beginning) (region-end)))
-             (function-name (which-function))
-             (processed-region-text region-text)
-             (command (if function-name
-                          (format "/ask in function %s, explain the following code block: %s"
-                                  function-name
-                                  processed-region-text)
-                        (format "/ask explain the following code block: %s"
-                                processed-region-text))))
-        (aider-add-current-file)
-        (aider--send-command command t))
-    (message "No region selected.")))
-
-;; New function to ask Aider to explain the function under the cursor
-;;;###autoload
-(defun aider-function-explain ()
-  "Ask Aider to explain the function under the cursor.
-Prompts user for specific questions about the function."
-  (interactive)
-  (if-let ((function-name (which-function)))
-      (let* ((prefix (format "explain %s: " function-name))
-             (prompt (format "Enter your question to %s" prefix))
-             (user-question (aider-read-string prompt)))
-        (aider-current-file-command-and-switch "/ask " (concat prefix user-question)))
-    (message "No function found at cursor position.")))
-
-;;;###autoload
-(defun aider-function-or-region-explain ()
-  "Call `aider-function-explain` when no region is selected.
-otherwise call `aider-region-explain`."
-  (interactive)
-  (if (region-active-p)
-      (aider-region-explain)
-    (aider-function-explain)))
 
 ;; New function to get command from user and send it prefixed with "/ask ", might be tough for AI at this moment
 ;;;###autoload

--- a/aider-helm.el
+++ b/aider-helm.el
@@ -27,16 +27,27 @@ CANDIDATE-LIST is an optional list of candidate strings to show before history."
                     (with-temp-buffer
                       (insert-file-contents history-file)
                       (delete-dups (read (buffer-string))))))
-         ;; Combine candidate-list and history with a separator
-         (candidates (if candidate-list
-                         (append candidate-list
-                                 (when history 
-                                   (cons "==================== HISTORY ========================================" history)))
-                       history))
+         ;; Extract the most recent item from history (if exists)
+         (most-recent (when (and history (not (null history)))
+                        (car history)))
+         ;; Remove the first item to add it back later
+         (rest-history (when (and history (not (null history)))
+                         (cdr history)))
+         ;; Combine completion list: most recent + candidates + separator + rest of history
+         (completion-list 
+          (append
+           ;; If most recent item exists, put it at the top
+           (when most-recent
+             (list most-recent))
+           ;; Add candidate list
+           (or candidate-list '())
+           ;; Add separator and rest of history
+           (when rest-history
+             (cons "==================== HISTORY ========================================" rest-history))))
          ;; Read input with helm
          (input (helm-comp-read
                  prompt
-                 candidates
+                 completion-list
                  :must-match nil
                  :name "Helm Read String, Use C-c C-y to edit selected command. C-b and C-f to move cursor during editing"
                  :fuzzy t

--- a/aider-helm.el
+++ b/aider-helm.el
@@ -31,7 +31,7 @@ CANDIDATE-LIST is an optional list of candidate strings to show before history."
          (candidates (if candidate-list
                          (append candidate-list 
                                  (when history 
-                                   (cons "--------------------PREVIOUS PROMPTS--------------------" history)))
+                                   (cons "==================== HISTORY ========================================" history)))
                        history))
          ;; Read input with helm
          (input (helm-comp-read

--- a/aider-helm.el
+++ b/aider-helm.el
@@ -15,21 +15,28 @@
 
 (declare-function helm-comp-read "helm-mode" (prompt collection &rest args))
 
-(defun aider-helm-read-string-with-history (prompt history-file-name &optional initial-input)
+(defun aider-helm-read-string-with-history (prompt history-file-name &optional initial-input template-list)
   "Read a string with Helm completion using specified history file.
 PROMPT is the prompt string.
 HISTORY-FILE-NAME is the base name for history file.
-INITIAL-INPUT is optional initial input string."
+INITIAL-INPUT is optional initial input string.
+TEMPLATE-LIST is an optional list of template strings to show before history."
   ;; Load history from file
   (let* ((history-file (expand-file-name history-file-name user-emacs-directory))
          (history (when (file-exists-p history-file)
                     (with-temp-buffer
                       (insert-file-contents history-file)
                       (delete-dups (read (buffer-string))))))
+         ;; Combine template-list and history with a separator
+         (candidates (if template-list
+                         (append template-list 
+                                 (when history 
+                                   (cons "----------PREVIOUS PROMPTS----------" history)))
+                       history))
          ;; Read input with helm
          (input (helm-comp-read
                  prompt
-                 history
+                 candidates
                  :must-match nil
                  :name "Helm Read String, Use C-c C-y to edit selected command. C-b and C-f to move cursor during editing"
                  :fuzzy t
@@ -44,11 +51,12 @@ INITIAL-INPUT is optional initial input string."
           (insert (prin1-to-string history-entries)))))
     input))
 
-(defun aider-helm-read-string (prompt &optional initial-input)
+(defun aider-helm-read-string (prompt &optional initial-input template-list)
   "Read a string with Helm completion for aider, showing historical inputs.
 PROMPT is the prompt string.
-INITIAL-INPUT is optional initial input string."
-  (aider-helm-read-string-with-history prompt "aider-helm-read-string-history.el" initial-input))
+INITIAL-INPUT is optional initial input string.
+TEMPLATE-LIST is an optional list of template strings to show before history."
+  (aider-helm-read-string-with-history prompt "aider-helm-read-string-history.el" initial-input template-list))
 
 (declare-function aider-read-string "aider")
 

--- a/aider-helm.el
+++ b/aider-helm.el
@@ -15,23 +15,23 @@
 
 (declare-function helm-comp-read "helm-mode" (prompt collection &rest args))
 
-(defun aider-helm-read-string-with-history (prompt history-file-name &optional initial-input template-list)
+(defun aider-helm-read-string-with-history (prompt history-file-name &optional initial-input candidate-list)
   "Read a string with Helm completion using specified history file.
 PROMPT is the prompt string.
 HISTORY-FILE-NAME is the base name for history file.
 INITIAL-INPUT is optional initial input string.
-TEMPLATE-LIST is an optional list of template strings to show before history."
+CANDIDATE-LIST is an optional list of candidate strings to show before history."
   ;; Load history from file
   (let* ((history-file (expand-file-name history-file-name user-emacs-directory))
          (history (when (file-exists-p history-file)
                     (with-temp-buffer
                       (insert-file-contents history-file)
                       (delete-dups (read (buffer-string))))))
-         ;; Combine template-list and history with a separator
-         (candidates (if template-list
-                         (append template-list 
+         ;; Combine candidate-list and history with a separator
+         (candidates (if candidate-list
+                         (append candidate-list 
                                  (when history 
-                                   (cons "----------PREVIOUS PROMPTS----------" history)))
+                                   (cons "--------------------PREVIOUS PROMPTS--------------------" history)))
                        history))
          ;; Read input with helm
          (input (helm-comp-read
@@ -51,12 +51,12 @@ TEMPLATE-LIST is an optional list of template strings to show before history."
           (insert (prin1-to-string history-entries)))))
     input))
 
-(defun aider-helm-read-string (prompt &optional initial-input template-list)
+(defun aider-helm-read-string (prompt &optional initial-input candidate-list)
   "Read a string with Helm completion for aider, showing historical inputs.
 PROMPT is the prompt string.
 INITIAL-INPUT is optional initial input string.
-TEMPLATE-LIST is an optional list of template strings to show before history."
-  (aider-helm-read-string-with-history prompt "aider-helm-read-string-history.el" initial-input template-list))
+CANDIDATE-LIST is an optional list of candidate strings to show before history."
+  (aider-helm-read-string-with-history prompt "aider-helm-read-string-history.el" initial-input candidate-list))
 
 (declare-function aider-read-string "aider")
 

--- a/aider-helm.el
+++ b/aider-helm.el
@@ -29,7 +29,7 @@ CANDIDATE-LIST is an optional list of candidate strings to show before history."
                       (delete-dups (read (buffer-string))))))
          ;; Combine candidate-list and history with a separator
          (candidates (if candidate-list
-                         (append candidate-list 
+                         (append candidate-list
                                  (when history 
                                    (cons "==================== HISTORY ========================================" history)))
                        history))

--- a/aider-prompt-mode.el
+++ b/aider-prompt-mode.el
@@ -80,7 +80,7 @@ returns nil."
 ;;;###autoload
 (defun aider-send-block-by-line ()
   "Send the current paragraph to aider line by line.
-Uses mark-paragraph to select the current paragraph, then sends it line by line."
+Uses `mark-paragraph` to select the current paragraph, then sends it by line."
   (interactive)
   (save-excursion                     ; preserve cursor position
     (mark-paragraph)                  ; mark paragraph
@@ -181,7 +181,7 @@ If file doesn't exist, create it with command binding help and sample prompt."
 (defun aider-prompt-cycle-file-command ()
   "Cycle through file commands in the current line.
 If the line doesn't contain a file command, add '/add ' to the beginning.
-If it already has one of '/add', '/read-only', or '/drop', cycle to the next one.
+If it already has one of '/add', '/read-only', or '/drop', cycle to the next.
 If it has '/ask', toggle to '/architect', and vice versa."
   (interactive)
   (let* ((file-commands '("/add " "/read-only " "/drop "))
@@ -193,20 +193,17 @@ If it has '/ask', toggle to '/architect', and vice versa."
          (current-command nil)
          (command-pos nil)
          (next-command "/add "))
-    
     ;; Check if line contains one of the file commands
     (dolist (cmd file-commands)
       (when (string-match (regexp-quote cmd) trimmed-line)
         (setq current-command cmd)
         (setq command-pos (+ line-begin (string-match (regexp-quote cmd) line-text)))))
-    
     ;; Check if line contains one of the special commands
     (unless current-command
       (dolist (cmd special-commands)
         (when (string-match (regexp-quote cmd) trimmed-line)
           (setq current-command cmd)
           (setq command-pos (+ line-begin (string-match (regexp-quote cmd) line-text))))))
-    
     ;; Determine the next command in the cycle
     (cond
      ;; For /ask and /architect, toggle between them
@@ -221,7 +218,6 @@ If it has '/ask', toggle to '/architect', and vice versa."
           (setq next-command (nth (mod (1+ cmd-index) (length file-commands)) file-commands)))))
      ;; Default case - no command found
      (t (setq next-command "/add ")))
-    
     ;; Apply the change
     (if current-command
         ;; Replace existing command

--- a/aider-prompt-mode.el
+++ b/aider-prompt-mode.el
@@ -181,9 +181,11 @@ If file doesn't exist, create it with command binding help and sample prompt."
 (defun aider-prompt-cycle-file-command ()
   "Cycle through file commands in the current line.
 If the line doesn't contain a file command, add '/add ' to the beginning.
-If it already has one of '/add', '/read-only', or '/drop', cycle to the next one."
+If it already has one of '/add', '/read-only', or '/drop', cycle to the next one.
+If it has '/ask', toggle to '/architect', and vice versa."
   (interactive)
   (let* ((file-commands '("/add " "/read-only " "/drop "))
+         (special-commands '("/ask " "/architect "))
          (line-begin (line-beginning-position))
          (line-end (line-end-position))
          (line-text (buffer-substring-no-properties line-begin line-end))
@@ -191,15 +193,35 @@ If it already has one of '/add', '/read-only', or '/drop', cycle to the next one
          (current-command nil)
          (command-pos nil)
          (next-command "/add "))
+    
     ;; Check if line contains one of the file commands
     (dolist (cmd file-commands)
       (when (string-match (regexp-quote cmd) trimmed-line)
         (setq current-command cmd)
         (setq command-pos (+ line-begin (string-match (regexp-quote cmd) line-text)))))
+    
+    ;; Check if line contains one of the special commands
+    (unless current-command
+      (dolist (cmd special-commands)
+        (when (string-match (regexp-quote cmd) trimmed-line)
+          (setq current-command cmd)
+          (setq command-pos (+ line-begin (string-match (regexp-quote cmd) line-text))))))
+    
     ;; Determine the next command in the cycle
-    (when current-command
+    (cond
+     ;; For /ask and /architect, toggle between them
+     ((string= current-command "/ask ")
+      (setq next-command "/architect "))
+     ((string= current-command "/architect ")
+      (setq next-command "/ask "))
+     ;; For file commands, cycle through the list
+     (current-command
       (let ((cmd-index (cl-position current-command file-commands :test 'string=)))
-        (setq next-command (nth (mod (1+ cmd-index) (length file-commands)) file-commands))))
+        (when cmd-index
+          (setq next-command (nth (mod (1+ cmd-index) (length file-commands)) file-commands)))))
+     ;; Default case - no command found
+     (t (setq next-command "/add ")))
+    
     ;; Apply the change
     (if current-command
         ;; Replace existing command

--- a/aider.el
+++ b/aider.el
@@ -84,7 +84,7 @@ Also based on aider LLM benchmark: https://aider.chat/docs/leaderboards/"
     ("f" "Add Current / Marked File (C-u: readonly)" aider-add-current-file-or-dired-marked-files)
     ("w" "Add All Files in Window" aider-add-files-in-current-window)
     ("d" "Add Same Type Files in dir" aider-add-same-type-files-under-dir)
-    ("O" "Drop Current File" aider-drop-current-file)
+    ;; ("O" "Drop Current File" aider-drop-current-file)
     ("m" "Show Last Commit (C-u: magit-log)" aider-magit-show-last-commit-or-log)
     ("u" "Undo Last Change" aider-undo-last-change)
     ("v" "Pull or Review Code Change" aider-pull-or-review-diff-file)
@@ -101,7 +101,7 @@ Also based on aider LLM benchmark: https://aider.chat/docs/leaderboards/"
     ("q" "Question on Function / Region" aider-ask-question)
     ("y" "Then Go Ahead" aider-go-ahead)
     ("Q" "Question without Context" aider-general-question)
-    ("D" "Debug Exception" aider-debug-exception)
+    ("e" "Debug Exception" aider-debug-exception)
     ("h" "Help (C-u: homepage)" aider-help)
     ("x" "Exit Aider" aider-exit)
     ]

--- a/aider.el
+++ b/aider.el
@@ -83,8 +83,8 @@ Also based on aider LLM benchmark: https://aider.chat/docs/leaderboards/"
    ["File Operation"
     ("f" "Add Current / Marked File (C-u: readonly)" aider-add-current-file-or-dired-marked-files)
     ("w" "Add All Files in Window" aider-add-files-in-current-window)
-    ("d" "Add Same Type Files in dir" aider-add-same-type-files-under-dir)
-    ;; ("O" "Drop Current File" aider-drop-current-file)
+    ;; ("d" "Add Same Type Files in dir" aider-add-same-type-files-under-dir)
+    ("O" "Drop Current File" aider-drop-current-file)
     ("m" "Show Last Commit (C-u: magit-log)" aider-magit-show-last-commit-or-log)
     ("u" "Undo Last Change" aider-undo-last-change)
     ("v" "Pull or Review Code Change" aider-pull-or-review-diff-file)


### PR DESCRIPTION
After this change, aider-ask-question (Question on Context), aider-general-question (Question without Context) and aider-function-or-region-refactor (Change function / region) provide a list of prompt candidates respectively, to reduce the typing effort for common code understanding / code refactoring task.