### PR TITLE
Fix: Support --subtree-only properly for large repo

### DIFF
--- a/HISTORY.org
+++ b/HISTORY.org
@@ -11,6 +11,7 @@
 - Added ~aider-core--auto-trigger-insert-prompt~. when ~aider-auto-trigger-prompt~ is t (default off), it will automatically trigger prompt insertion in aider comint session after one of the commands (/ask, /code, /architect).
 - aider--comint-send-string-syntax-highlight use comint-send-input since it is a more standard way, given suggestion from Spike-Leung
 - In aider-prompt-file, C-u C-c C-n can send block line by line in aider prompt file (close to C-c C-n)
+- aider-run-aider in dired buffer will ask if user wants to add `--subtree-only` flag
 
 ** v0.5.5
 

--- a/README.org
+++ b/README.org
@@ -164,6 +164,7 @@ Otherwise, You can have helm-based completion with run the following code, after
     - Git repository identification is based on the current file's path
     - Multiple Aider sessions can run simultaneously for different Git repositories
     - When being called with the universal argument (~C-u~), a prompt will offer the user to change the content of ~aider-args~ for this session.
+    - When run it in a dired directory, it will ask you if you want to add [[https://aider.chat/docs/config/options.html#--subtree-only][--subtree-only flag]], which only consider files in that dired subtree, to make it faster
   - aider-switch-to-buffer :: Switch to the Aider buffer.
     - use ~^~ in the menu to toggle open aider session in other window inside current frame, or open a dedicate frame for aider session. This is useful when there is more than one monitor, and one frame / monitor is used to hold multi buffers for code, and another frame / monitor hold aider session.
 

--- a/README.org
+++ b/README.org
@@ -288,8 +288,8 @@ Otherwise, You can have helm-based completion with run the following code, after
   - Aider use .aiderignore file to handle this, [[https://aider.chat/docs/faq.html#can-i-use-aider-in-a-large-mono-repo][detail]], or, you can turn off git with --no-git in aider-args.
   - Or, use the --subtree-only with following way in emacs:
     - Used dired to open the directory (subtree) to be included
-    - C-c a open the menu, C-u a to run aider with args
-    - add --subtree-only to the end of args, and start aider
+    - C-c a a to trigger aider-run-aider
+    - Answer yes about --subtree-only question, it will add the flag
    
 - How to let aider work with your speaking language?
   - use [[https://aider.chat/docs/usage/conventions.html#specifying-coding-conventions][aider coding conventions]]. In my case, I added "- reply in Chinese" to the CONVENTIONS.md file, and load work through [[https://aider.chat/docs/config/aider_conf.html][.aider.conf.yml]]. Or, put sth like following into aider-args variable. 

--- a/README.org
+++ b/README.org
@@ -287,9 +287,9 @@ Otherwise, You can have helm-based completion with run the following code, after
 - In large mono repo, aider take long time to scan the repo. How to improve?
   - Aider use .aiderignore file to handle this, [[https://aider.chat/docs/faq.html#can-i-use-aider-in-a-large-mono-repo][detail]], or, you can turn off git with --no-git in aider-args.
   - Or, use the --subtree-only with following way in emacs:
-    - Used dired to open the directory (subtree) you want to start emacs
+    - Used dired to open the directory (subtree) to be included
     - C-c a open the menu, C-u a to run aider with args
-    - add --subtree-only to the end of args
+    - add --subtree-only to the end of args, and start aider
    
 - How to let aider work with your speaking language?
   - use [[https://aider.chat/docs/usage/conventions.html#specifying-coding-conventions][aider coding conventions]]. In my case, I added "- reply in Chinese" to the CONVENTIONS.md file, and load work through [[https://aider.chat/docs/config/aider_conf.html][.aider.conf.yml]]. Or, put sth like following into aider-args variable. 

--- a/README.org
+++ b/README.org
@@ -286,6 +286,10 @@ Otherwise, You can have helm-based completion with run the following code, after
 
 - In large mono repo, aider take long time to scan the repo. How to improve?
   - Aider use .aiderignore file to handle this, [[https://aider.chat/docs/faq.html#can-i-use-aider-in-a-large-mono-repo][detail]], or, you can turn off git with --no-git in aider-args.
+  - Or, use the --subtree-only with following way in emacs:
+    - Used dired to open the directory (subtree) you want to start emacs
+    - C-c a open the menu, C-u a to run aider with args
+    - add --subtree-only to the end of args
    
 - How to let aider work with your speaking language?
   - use [[https://aider.chat/docs/usage/conventions.html#specifying-coding-conventions][aider coding conventions]]. In my case, I added "- reply in Chinese" to the CONVENTIONS.md file, and load work through [[https://aider.chat/docs/config/aider_conf.html][.aider.conf.yml]]. Or, put sth like following into aider-args variable. 

--- a/README.org
+++ b/README.org
@@ -315,12 +315,11 @@ Otherwise, You can have helm-based completion with run the following code, after
   - [X] Current aider-ask-question need to be improved, since there could be so many different question to ask
   - [X] How to port the candidate list feature to aider-plain-read-string
   - [ ] Thinking on how to improve the candidate list for the function
-- More thinking on how to simplify the menu / commands
 - More thinking on improving code quality tool such as unit-test [/]
   - [X] Code refactoring functions
   - [ ] TDD functions
   - [ ] Code reading functions 
-- [X] Tag release version, make it available on melpa stable
+- More thinking on how to simplify the menu / commands
 
 ** Code quality
  

--- a/aider-code-change.el
+++ b/aider-code-change.el
@@ -233,9 +233,11 @@ Works across different programming languages."
             (let* ((current-name (or (thing-at-point 'symbol t)
                                     (read-string "Current name: ")))
                    (new-name (read-string (format "Rename '%s' to: " current-name))))
-              (-> technique-description
-                  (replace-regexp-in-string "\\[CURRENT_NAME\\]" current-name t)
-                  (replace-regexp-in-string "\\[NEW_NAME\\]" new-name t))))
+              (replace-regexp-in-string 
+               "\\[NEW_NAME\\]" new-name
+               (replace-regexp-in-string 
+                "\\[CURRENT_NAME\\]" current-name technique-description t) 
+               t))))
            ((string= selected-technique "Inline Method")
             (let ((method-name (or (thing-at-point 'symbol t)
                                   (read-string "Method to inline: "))))
@@ -248,9 +250,11 @@ Works across different programming languages."
             (let ((method-name (or current-function  ; current-function already contains which-function result
                                   (read-string "Method to move: ")))
                   (target-class (read-string "Target class: ")))
-              (-> technique-description
-                  (replace-regexp-in-string "\\[METHOD_NAME\\]" method-name t)
-                  (replace-regexp-in-string "\\[TARGET_CLASS\\]" target-class t))))
+              (replace-regexp-in-string 
+               "\\[TARGET_CLASS\\]" target-class
+               (replace-regexp-in-string 
+                "\\[METHOD_NAME\\]" method-name technique-description t) 
+               t))))
            ((string= selected-technique "Extract Variable")
             (let ((var-name (read-string "New variable name: ")))
               (replace-regexp-in-string "\\[VARIABLE_NAME\\]" var-name technique-description t)))

--- a/aider-code-change.el
+++ b/aider-code-change.el
@@ -237,7 +237,7 @@ Works across different programming languages."
                "\\[NEW_NAME\\]" new-name
                (replace-regexp-in-string 
                 "\\[CURRENT_NAME\\]" current-name technique-description t) 
-               t))))
+               t)))
            ((string= selected-technique "Inline Method")
             (let ((method-name (or (thing-at-point 'symbol t)
                                   (read-string "Method to inline: "))))
@@ -254,7 +254,7 @@ Works across different programming languages."
                "\\[TARGET_CLASS\\]" target-class
                (replace-regexp-in-string 
                 "\\[METHOD_NAME\\]" method-name technique-description t) 
-               t))))
+               t)))
            ((string= selected-technique "Extract Variable")
             (let ((var-name (read-string "New variable name: ")))
               (replace-regexp-in-string "\\[VARIABLE_NAME\\]" var-name technique-description t)))

--- a/aider-core.el
+++ b/aider-core.el
@@ -225,7 +225,6 @@ If current buffer is a dired buffer, ask if user wants to use --subtree-only mod
       ;; Check if --subtree-only is already in the arguments
       (unless (member "--subtree-only" current-args)
         (setq current-args (append current-args '("--subtree-only")))))
-    
     (unless (comint-check-proc buffer-name)
       (apply #'make-comint-in-buffer "aider" buffer-name aider-program nil current-args)
       (with-current-buffer buffer-name

--- a/aider-core.el
+++ b/aider-core.el
@@ -223,7 +223,7 @@ With the universal argument EDIT-ARGS, prompt to edit aider-args before running.
       (with-current-buffer buffer-name
         (aider-comint-mode))
       (message "%s" (if current-args
-                       (format "Running aider with args: %s" (mapconcat #'identity current-args " "))
+                       (format "Running aider from %s, with args: %s" default-directory (mapconcat #'identity current-args " "))
                      "Running aider with no args provided.")))
     (aider-switch-to-buffer)))
 

--- a/aider-core.el
+++ b/aider-core.el
@@ -209,7 +209,8 @@ If the current buffer is already the Aider buffer, do nothing."
 ;;;###autoload
 (defun aider-run-aider (&optional edit-args)
   "Create a comint-based buffer and run \"aider\" for interactive conversation.
-With the universal argument EDIT-ARGS, prompt to edit aider-args before running."
+With the universal argument EDIT-ARGS, prompt to edit aider-args before running.
+If current buffer is a dired buffer, ask if user wants to use --subtree-only mode."
   (interactive "P")
   (let* ((buffer-name (aider-buffer-name))
          (comint-terminfo-terminal "dumb")
@@ -218,6 +219,13 @@ With the universal argument EDIT-ARGS, prompt to edit aider-args before running.
                             (read-string "Edit aider arguments: "
                                          (mapconcat #'identity aider-args " ")))
                          aider-args)))
+    ;; Check if current buffer is in dired-mode and prompt for --subtree-only
+    (when (and (eq major-mode 'dired-mode)
+               (y-or-n-p "Current buffer is a directory. Use --subtree-only mode?"))
+      ;; Check if --subtree-only is already in the arguments
+      (unless (member "--subtree-only" current-args)
+        (setq current-args (append current-args '("--subtree-only")))))
+    
     (unless (comint-check-proc buffer-name)
       (apply #'make-comint-in-buffer "aider" buffer-name aider-program nil current-args)
       (with-current-buffer buffer-name

--- a/aider-file.el
+++ b/aider-file.el
@@ -33,12 +33,17 @@
 
 ;;;###autoload
 (defun aider-action-current-file (command-prefix)
-  "Perform the COMMAND-PREFIX to aider session."
+  "Perform the COMMAND-PREFIX to aider session.
+If the file is in a git repository, use path relative to git root."
   ;; Ensure the current buffer is associated with a file
   (if (not buffer-file-name)
       (message "Current buffer is not associated with a file.")
-    (let* ((local-name (file-local-name
-                        (expand-file-name buffer-file-name)))
+    (let* ((git-root (ignore-errors (magit-toplevel)))
+           (local-name (if git-root
+                           ;; Get path relative to git root
+                           (file-relative-name (expand-file-name buffer-file-name) git-root)
+                         ;; Use existing logic for non-git files
+                         (file-local-name (expand-file-name buffer-file-name))))
            (formatted-path (if (string-match-p " " local-name)
                              (format "\"%s\"" local-name)
                            local-name))

--- a/aider-file.el
+++ b/aider-file.el
@@ -12,7 +12,7 @@
 (require 'aider-core)
 (require 'dired)
 
-;; 新增辅助函数，用于获取文件的相对路径或绝对路径
+;; Added helper function to get the relative or absolute path of the file
 (defun aider--get-file-path (file-path)
   "Get the appropriate path for FILE-PATH.
 If the file is in a git repository, return path relative to git root.
@@ -25,7 +25,7 @@ Otherwise, return the full local path."
       ;; Use full path for non-git files
       (file-local-name full-path))))
 
-;; 新增辅助函数，用于格式化文件路径（处理空格）
+;; Added helper function to format file paths (process spaces)
 (defun aider--format-file-path (file-path)
   "Format FILE-PATH for use in commands.
 Add quotes if the path contains spaces."

--- a/aider-file.el
+++ b/aider-file.el
@@ -38,7 +38,7 @@
   (if (not buffer-file-name)
       (message "Current buffer is not associated with a file.")
     (let* ((local-name (file-local-name
-                       (expand-file-name buffer-file-name)))
+                        (expand-file-name buffer-file-name)))
            (formatted-path (if (string-match-p " " local-name)
                              (format "\"%s\"" local-name)
                            local-name))


### PR DESCRIPTION
Previously I thought it works until really use it by myself on large repo.. The issue is that after start the aider in a git sub directory, add file with aider-action-current-file won't work, because currently aider.el use full path of source code file, and aider refuse to accept that with --subtree-only mode (sounds like inconsistent?). Instead, relative file path from git root works for both of w/wo of -subtree-only. This fix is about to use relative path instead when use git

Also updated FAQ about how to use --subtree-only.

Addressing https://github.com/tninja/aider.el/issues/23
