### PR TITLE
Fix: Better color rendering for aider-comint-buffer, especially on prompt input line

### DIFF
--- a/HISTORY.org
+++ b/HISTORY.org
@@ -4,6 +4,8 @@
 ** main branch change
 
 - fix aider--analyze-module function. It now accept a module directory provided by user, /read-only, and then analyze the module using the prompt.
+- Better color rendering for aider-comint-buffer, especially on prompt input line
+  - from the line and below in this PR: https://github.com/MatthewZMD/aidermacs/pull/119/files#diff-1865a6c95bb14150b7acdc358d45da54237ced17219de644e1194b6e1bcab04eR387
 
 ** v0.8.1
 

--- a/HISTORY.org
+++ b/HISTORY.org
@@ -6,7 +6,6 @@
 - fix aider--analyze-module function. It now accept a module directory provided by user, /read-only, and then analyze the module using the prompt.
 - Better color rendering for aider-comint-buffer, especially on prompt input line
   - from the line and below in this PR: https://github.com/MatthewZMD/aidermacs/pull/119/files#diff-1865a6c95bb14150b7acdc358d45da54237ced17219de644e1194b6e1bcab04eR387
-
 - Add [Suggest Refactoring Strategy] menu item in the code refactoring tool
 - refactor aider-agile.el, breakdown large methods to smaller ones
 - Make TDD refactoring stage call aider-refactor-book-method, and tell it to pass all tests

--- a/aider-core.el
+++ b/aider-core.el
@@ -60,17 +60,11 @@ Ignore lines starting with '>' (command prompts/input)."
   ;; 3) Reuse `markdown-mode`'s font-lock keywords for highlighting,
   ;;    but add a rule to prevent markdown highlighting on lines starting with '>'.
   (setq-local font-lock-defaults
-              (list (cons
-                     ;; Rule to apply default face to prompt lines, without overriding.
-                     ;; This aims to prevent subsequent markdown rules in this list
-                     ;; from applying, while still allowing comint-highlight-input.
-                     '("^>.*$" 0 'default nil)
-                     ;; Original markdown keywords
-                     markdown-mode-font-lock-keywords)
-                    nil ;; KEYWORDS-ONLY
-                    nil ;; CASE-FOLD
-                    nil ;; SYNTAX-ALIST
-                    nil)) ;; SYNTAX-BEGIN
+              '(markdown-mode-font-lock-keywords
+                nil nil nil nil
+                (font-lock-multiline . t)
+                (font-lock-extra-managed-props
+                 . (composition display invisible))))
   ;; 4) Enable fenced code block highlighting, and disable special font processing:
   (setq-local markdown-fontify-code-blocks-natively t)
   ;; https://github.com/tninja/aider.el/issues/113
@@ -89,7 +83,18 @@ Ignore lines starting with '>' (command prompts/input)."
   (font-lock-mode 1)
   ;; 7) Force immediate fontification of visible area:
   (font-lock-flush)
-  (font-lock-ensure))
+  (font-lock-ensure)
+  ;; 8) from https://github.com/MatthewZMD/aidermacs/pull/119/files
+  ;; Enable markdown mode highlighting
+  (add-hook 'syntax-propertize-extend-region-functions
+            #'markdown-syntax-propertize-extend-region nil t)
+  (add-hook 'jit-lock-after-change-extend-region-functions
+            #'markdown-font-lock-extend-region-function t t)
+  ;; a regex that will never match so we don't get the prompt interpreted as a block quote
+  (setq-local markdown-regex-blockquote "^\\_>$")
+  (if markdown-hide-markup
+      (add-to-invisibility-spec 'markdown-markup)
+    (remove-from-invisibility-spec 'markdown-markup)))
 
 (define-derived-mode aider-comint-mode comint-mode "Aider Session"
   "Major mode for interacting with Aider.

--- a/aider-core.el
+++ b/aider-core.el
@@ -258,8 +258,8 @@ If current buffer is a dired, eshell, or shell buffer, ask if user wants to use 
       (with-current-buffer buffer-name
         (aider-comint-mode))
       (message "%s" (if current-args
-                       (format "Running aider from %s, with args: %s" default-directory (mapconcat #'identity current-args " "))
-                     (format "Running aider from %s with no args provided." default-directory))))
+                       (format "Running aider from %s, with args: %s.\nMay the AI force be with you!" default-directory (mapconcat #'identity current-args " "))
+                     (format "Running aider from %s with no args provided.\nMay the AI force be with you!" default-directory))))
     (aider-switch-to-buffer)))
 
 (defun aider-input-sender (proc string)


### PR DESCRIPTION
They are basically from the line and after that in this PR: https://github.com/MatthewZMD/aidermacs/pull/119/files#diff-1865a6c95bb14150b7acdc358d45da54237ced17219de644e1194b6e1bcab04eR387

Thanks @CeleritasCelery 

I tried and it can resolve https://github.com/tninja/aider.el/issues/126. @ahyatt would be great if you can test it from this branch.

I admit that I have little knowledge on these magic. And seems LLMs know some but cannot guarantee to be a stable expert.