### PR TITLE
Add subtree-only command to aider-prompt-mode

### DIFF
--- a/HISTORY.org
+++ b/HISTORY.org
@@ -8,6 +8,8 @@
 - Add [Suggest Refactoring Strategy] menu item in the code refactoring tool
 - refactor aider-agile.el, breakdown large methods to smaller ones
 - Make TDD refactoring stage call aider-refactor-book-method, and tell it to pass all tests
+- Add "subtree-only" command in aider-prompt-mode.el, when user send "subtree-only <dir>" with C-c C-n, it will start aider session at the given directory with --subtree-only
+- fix doom keybinding in README.org
 
 ** v0.8.1
 
@@ -21,6 +23,7 @@
 - Introduce aider-legacy-code.el, it provides legacy code handling techniques based on Michael Feathers' "Working Effectively with Legacy Code" for the Aider package.
 - Re-organize README to make it easier to read.
 - Fix the bug in aider--analyze-program-structure, provided by EdmondFrank.
+- remove +aider-code-change+ menu item, since It bypass code review. The code quality is not as good as /architect.
 
 ** v0.7.0
 

--- a/README.org
+++ b/README.org
@@ -312,7 +312,7 @@ If you used installed aider.el through melpa and package-install, just neecd to 
   - Spike-Leung said [[https://github.com/tninja/aider.el/issues/117#issuecomment-2764420079][add hook to it will help]]
 
 - Why aider-code-change got disabled in transient menu?
-  - It is not recommended. The code quality is not as good as /architect. Discussed here: https://github.com/tninja/aider.el/issues/128
+  - It bypass code review and is not recommended. The code quality is not as good as /architect. Discussed here: https://github.com/tninja/aider.el/issues/128
 
 * TODO Future work
 

--- a/README.org
+++ b/README.org
@@ -173,6 +173,10 @@ If you used installed aider.el through melpa and package-install, just neecd to 
 
 [[file:./aider_prompt_file.png]]
 
+- start aider session in a sub-tree inside aider prompt file:
+  - Use ~subtree-only <dir>~ to start aider session in a sub-tree, where <dir> is the directory to start the session.
+  - This is useful when you want to work on a sub-directory of a large mono repo, and don't want to wait for aider to scan the entire repo.
+
 **** [[./snippets/aider-prompt-mode][Prompt Snippets]]
 
 - Prompts for aider might share similar structure. Yasnippet can be used to help reusing these prompts.
@@ -203,20 +207,12 @@ If you used installed aider.el through melpa and package-install, just neecd to 
 ** AI assisted Code reading
 
 - [[https://www.amazon.com/Code-Reading-Open-Source-Perspective/dp/0201799405/ref=sr_1_1?crid=39HOB4975Y8LZ&dib=eyJ2IjoiMSJ9.fjkryt7JHaLWMQ5xuSPTED-gJR52Wqh448RQ3TrsTPYAFNpx--gA-mTNGqRQqebb.rnvw74YGEJXCRRe0UIwUSwAaeEngg0MpraxcTOBRn5Q&dib_tag=se&keywords=Code+Reading%3A+The+Open+Source+Perspective&qid=1744517167&s=books&sprefix=code+reading+the+open+source+perspective%2Cstripbooks%2C254&sr=1-1][Code Reading: The Open Source Perspective, by Diomidis Spinellis]]: ~aider-code-read~
+
 * Pros and Cons 
+
 ** Pros: UI, Context Awareness AI Pair Programming
 
-- Pop-up Menu (~aider-transient-menu~)
-
-- Git repository-specific Aider session management
-  
-- Integrating context (buffer / things under cursor / region) with aider, semi-automatically build up prompt. easy search / reuse previous prompt with helm
-  
-- Menu items for AI-assistant programming workflow. AI assisted Agile development methods. AI assisted Code reading
-  
-- Aider prompt file to organize relative large code change task, and make it reproducible. Interacting with aider session from it following ESS way. Yasnippet support to reuse good prompts from community.
-
-- AI assisted Code reading tools based on classic book
+- Already introduced in this README
 
 ** Cons: aider session in comint is not fancy
 

--- a/README.org
+++ b/README.org
@@ -295,6 +295,7 @@ If you used installed aider.el through melpa and package-install, just neecd to 
     - Used dired, eshell, or shell buffer to go to the directory (subtree) to be included
     - C-c a a to trigger aider-run-aider
     - Answer yes about --subtree-only question, it will add the flag
+  - Or, in aider prompt file, use ~subtree-only <dir>~ to specify where to start, and use C-c C-n to start aider session at that directory, it start with --subtree-only 
    
 - How to let aider work with your speaking language?
   - use [[https://aider.chat/docs/usage/conventions.html#specifying-coding-conventions][aider coding conventions]]. In my case, I added "- reply in Chinese" to the CONVENTIONS.md file, and load work through [[https://aider.chat/docs/config/aider_conf.html][.aider.conf.yml]]. Or, put sth like following into aider-args variable. 

--- a/aider-agile.el
+++ b/aider-agile.el
@@ -179,9 +179,13 @@ If TDD-MODE is non-nil, adds TDD constraints to the prompt."
          (code-snippet (if region-active
                            (format "\n```\n%s\n```" region-text)
                          ""))
+         ;; Get the main instruction from the user
+         (user-instruction (aider-read-string "Edit suggestion request: " "Analyze the following code context and suggest appropriate refactoring strategy."))
          ;; Add TDD constraint if in TDD mode
          (tdd-constraint (if tdd-mode " Ensure all tests still pass after refactoring." ""))
-         (base-prompt (format "Analyze the following code context and suggest appropriate refactoring strategy. Context: %s%s"
+         ;; Construct the prompt using user input and context
+         (base-prompt (format "%s Context: %s%s"
+                              user-instruction
                               context-info
                               code-snippet))
          (prompt (concat base-prompt tdd-constraint))

--- a/aider-discussion.el
+++ b/aider-discussion.el
@@ -28,7 +28,8 @@ Focuses on understanding, analyzing, improving the selected code or function."
                   (function-name (format "About function '%s': " function-name))
                   (region-active "Question for the selected region: ")
                   (t "Question: ")))
-         (candidate-list '("What is your suggestion on the most important thing to do"
+         (candidate-list '("What kind of question do you have about this code?"
+                           "What is your suggestion on the most important thing to do"
                           "Carefully review this file and suggest improvements"
                           "What does this code do? Explain the logic of this code step by step"
                           "What are the inputs and outputs of this code?"


### PR DESCRIPTION
During using aider.el, it is found that --subtree-mode was useful for large repo, and it would be great if there is a **reproducible way** to start aider with --subtree-mode in a particular directory (there are ways to do it but require more manual operations). Example use cases: Multiple feature changes need to work in same sub-module, are it would be great to have a way to easily start aider session with this setting in new feature change work. 

To address this problem, subtree-only command in aider prompt file is introduced, to start aider session given target directory (relative path to git root).

The way to use this command is:
```
subtree-mode <dir>
```

And the whole command block might looks like:
```
* My task on sub-module <dir>

subtree-mode <dir>

/read-only <file1>
/add <file2>

/architect <prompt>
```

so that the whole command block is reproducible for the task and it can run step by step in the aider prompt file.

and use C-c C-n to start the aider session with it in aider-prompt-file (C-c a p open that). (if there is existing aider session, need to kill that buffer firstly). It will start aider in that directory, with --subtree-mode added.

This is an enhancement to https://github.com/tninja/aider.el/issues/23
