### PR TITLE
Feat: aider-pull-or-review-diff-file support pull changes for magit staged files, as default option

### DIFF
--- a/HISTORY.org
+++ b/HISTORY.org
@@ -9,6 +9,7 @@
 - README improvement
 - Updated Chinese version of README
 - aider-pull-or-review-diff-file support pull changes for magit staged files, as default option
+- refactor the code review function since it has grown very large, with C-c a R (LLM suggest the refactoring strategy and I go ahead to accept it).
 
 ** v0.8.4
 

--- a/HISTORY.org
+++ b/HISTORY.org
@@ -8,6 +8,7 @@
 - aider-change-model will ask reasoning-effort for chatgpt o4,o3,o1 model, when it is main model change
 - README improvement
 - Updated Chinese version of README
+- aider-pull-or-review-diff-file support pull changes for magit staged files, as default option
 
 ** v0.8.4
 

--- a/README.org
+++ b/README.org
@@ -228,8 +228,9 @@ If you used installed aider.el through melpa and package-install, just neecd to 
 * Cons of aider.el
 
 - The current implementation is using comint to host aider session, a classic CLI interactive solution used in emacs, However, comint-mode initially _doesn't have the advance features such as codeblock color rendering and file tracking_ from aider.
-  - *color rendering markdown-mode.el is applied and largely improved this*.
+  - *color rendering from markdown-mode.el is applied in aider comint session buffer it and largely improved this*.
   - Without file tracking, aider.el cannot do [[https://aider.chat/docs/usage/watch.html#ai-comments][AI comments]]. *The work around we provided is ~aider-implement-todo~*, It use architect command to ask aider to implement comment under cursor by default. I constantly use this feature and feel it is OK.
+  - [[https://github.com/akermu/emacs-libvterm][vterm based interactive session]] can make the aider session close to the user experience of using aider in terminal. Considering that comint based solution is battle tested for many years and it is very stable, and long term maintainability of the project, aider.el only use comint session based solution. 
 
 * Be careful about AI generated code
 

--- a/README.org
+++ b/README.org
@@ -2,6 +2,10 @@
 
 #+TITLE: AI assisted programming in Emacs with Aider 
 
+[[https://melpa.org/#/aider][https://melpa.org/packages/aider-badge.svg]]
+[[https://stable.melpa.org/#/aider][https://stable.melpa.org/packages/aider-badge.svg]]
+[[https://github.com/tninja/aider.el/graphs/contributors][https://img.shields.io/github/contributors/tninja/aider.el.svg]]
+
 [[file:README.zh-cn.org][中文版]]
 
 * Table of Contents

--- a/README.org
+++ b/README.org
@@ -227,15 +227,9 @@ If you used installed aider.el through melpa and package-install, just neecd to 
 
 * Cons of aider.el
 
-- aider session in comint is not fancy
-
 - The current implementation is using comint to host aider session, a classic CLI interactive solution used in emacs, However, comint-mode initially _doesn't have the advance features such as codeblock color rendering and file tracking_ from aider.
   - *color rendering markdown-mode.el is applied and largely improved this*.
   - Without file tracking, aider.el cannot do [[https://aider.chat/docs/usage/watch.html#ai-comments][AI comments]]. *The work around we provided is ~aider-implement-todo~*, It use architect command to ask aider to implement comment under cursor by default. I constantly use this feature and feel it is OK.
-
-- *It's generally not advantageous to interact with Aider extensively through the comint terminal directly.* Instead, since the comint terminal is well integrated with other parts of emacs, it is encouraged to generate and send prompt to it, either from:
-  - Code buffer directly by _aider code change related commands_ or _ask question related commands_. It make less context switching, and it help building up prompt, reducing manual typing.
-  - Aider prompt file (~aider-open-prompt-file~, ~C-c a p~). This is the traditional way in emacs to communicate with comint buffer (just like ESS, python-mode, scala-mode, etc). It is easy to revisit your used commands, organize and manage large code change requiring more prompts and break them into sub-tasks (cause it is org), and it is easy for multi-line prompts. Recently, syntax highlight, completion and snippets were added to this file, and it is now a good place to write and organize your prompts.
 
 * Be careful about AI generated code
 

--- a/README.org
+++ b/README.org
@@ -13,7 +13,7 @@
   - [[#helm-support][Helm Support]]
 - [[#most-used-features-integrated-into-the-aider-menu][Most used features (integrated into the aider menu)]]
 - [[#methods-from-classic-books][Methods from classic books]]
-- [[#pros-and-cons][Pros and Cons]]
+- [[#cons-of-aider.el][Cons of aider.el]]
 - [[#be-careful-about-ai-generated-code][Be careful about AI generated code]]
 - [[#faq][FAQ]]
 - [[#future-work][Future work]]
@@ -162,7 +162,7 @@ If you used installed aider.el through melpa and package-install, just neecd to 
 *** Support for Agile Development
   - aider-write-unit-test :: If the current buffer is main source code file, generate comprehensive unit tests for the current function or file. If the cursor is in a test source code file, when the cursor is on a test function, implement the test function. Otherwise, provide description to implement the test function (or spec).
   - If main source code break and test function fails, use ~aider-function-or-region-refactor~ on the failed test function to ask Aider to fix the code to make the test pass.
-  - aider-refactor-book-method :: for code refactoring using techniques from [[https://www.amazon.com/Refactoring-Improving-Existing-Addison-Wesley-Signature/dp/0134757599/ref=asc_df_0134757599?mcid=2eb8b1a5039a3b7c889ee081fc2132e0&hvocijid=16400341203663661896-0134757599-&hvexpln=73&tag=hyprod-20&linkCode=df0&hvadid=721245378154&hvpos=&hvnetw=g&hvrand=16400341203663661896&hvpone=&hvptwo=&hvqmt=&hvdev=c&hvdvcmdl=&hvlocint=&hvlocphy=9032161&hvtargid=pla-2281435180458&psc=1][Martin Flower's Refactoring book]], you can also let AI make the decision on how to refactor. 
+  - aider-refactor-book-method :: for code refactoring using techniques from [[https://www.amazon.com/Refactoring-Improving-Existing-Addison-Wesley-Signature/dp/0134757599/ref=asc_df_0134757599?mcid=2eb8b1a5039a3b7c889ee081fc2132e0&hvocijid=16400341203663661896-0134757599-&hvexpln=73&tag=hyprod-20&linkCode=df0&hvadid=721245378154&hvpos=&hvnetw=g&hvrand=16400341203663661896&hvpone=&hvptwo=&hvqmt=&hvdev=c&hvdvcmdl=&hvlocint=&hvlocphy=9032161&hvtargid=pla-2281435180458&psc=1][Martin Flower's Refactoring book]], you can also let AI make the decision on how to refactor, example: [[https://github.com/tninja/aider.el/pull/146/commits/811a8eca47dfba3c52a33afba7bb11a8a69689b1][this commit]] addressing [[https://github.com/tninja/aider.el/pull/146#discussion_r2078182430][this comment]]
   - aider-pull-or-review-diff-file :: let aider to pull and review the code change.
 
 *** Questions on code
@@ -221,13 +221,9 @@ If you used installed aider.el through melpa and package-install, just neecd to 
 
 - [[https://www.amazon.com/Code-Reading-Open-Source-Perspective/dp/0201799405/ref=sr_1_1?crid=39HOB4975Y8LZ&dib=eyJ2IjoiMSJ9.fjkryt7JHaLWMQ5xuSPTED-gJR52Wqh448RQ3TrsTPYAFNpx--gA-mTNGqRQqebb.rnvw74YGEJXCRRe0UIwUSwAaeEngg0MpraxcTOBRn5Q&dib_tag=se&keywords=Code+Reading%3A+The+Open+Source+Perspective&qid=1744517167&s=books&sprefix=code+reading+the+open+source+perspective%2Cstripbooks%2C254&sr=1-1][Code Reading: The Open Source Perspective, by Diomidis Spinellis]]: ~aider-code-read~
 
-* Pros and Cons 
+* Cons of aider.el
 
-** Pros: UI, Context Awareness AI Pair Programming
-
-- Already introduced in this README
-
-** Cons: aider session in comint is not fancy
+- aider session in comint is not fancy
 
 - The current implementation is using comint to host aider session, a classic CLI interactive solution used in emacs, However, comint-mode initially _doesn't have the advance features such as codeblock color rendering and file tracking_ from aider.
   - *color rendering markdown-mode.el is applied and largely improved this*.

--- a/README.org
+++ b/README.org
@@ -180,7 +180,7 @@ If you used installed aider.el through melpa and package-install, just neecd to 
 
 - People happy with sending code from editor buffer to comint buffer (eg. ESS, python-mode, scala-mode) might like this. This is a interactive and reproducible way
 
-- ~C-c C-n~ key can be used to send the current prompt line to the comint buffer. Or batch send selected region line by line. To my experience, this is the most used method in aider prompt file.
+- ~C-c C-n~ key can be used to send the current prompt line to the comint buffer. Or batch send selected region line by line (~C-u C-c C-n~). To my experience, this is the most used method in aider prompt file.
 
 - ~C-c C-c~ key is for multi-line prompt. The following example shows ~C-c C-c~ key pressed when cursor is on the prompt.
 

--- a/aider-core.el
+++ b/aider-core.el
@@ -209,7 +209,7 @@ Optional LOG, when non-nil, logs the command to the message area."
         (if (and aider-process (comint-check-proc aider-buffer))
             (progn
               ;; Send the command to the aider process
-              (aider--comint-send-string-syntax-highlight aider-buffer (concat command "\n"))
+              (aider--comint-send-string-syntax-highlight aider-buffer command)
               ;; Provide feedback to the user
               (when log
                 (message "Sent command to aider buffer: %s" (string-trim command)))

--- a/aider-file.el
+++ b/aider-file.el
@@ -229,7 +229,7 @@ Otherwise, it's treated as base branch and diff is generated against HEAD."
     (unless git-root
       (user-error "Not in a git repository"))
     ;; Fetch from all remotes to ensure we have the latest branches
-    (let* ((raw-range (read-string "Branch range (base..feature), commit hash, or base branch: " "main"))
+    (let* ((raw-range (read-string "Branch range (base..feature), commit hash, base branch, or cached: " "cached"))
            (range (string-trim raw-range))
          ;; Check if it's a commit hash by verifying:
          ;; 1. It doesn't contain '..'

--- a/aider-file.el
+++ b/aider-file.el
@@ -263,7 +263,6 @@ Otherwise, it's treated as base branch and diff is generated against HEAD."
                   (setq feature-branch "HEAD"))
                 (concat base-branch "." feature-branch)))))) ; for filename part
        (diff-file (concat git-root diff-file-name-part ".diff")))
-
     ;; Main logic based on is-cached-diff
     (if is-cached-diff
         ;; Handle cached diff
@@ -304,7 +303,7 @@ Otherwise, it's treated as base branch and diff is generated against HEAD."
                        (concat "--output=" diff-file))))
     ;; Open diff file (common to both paths)
     (find-file diff-file)
-    (message "Generated diff file: %s" diff-file)))
+    (message "Generated diff file: %s" diff-file))))
 
 ;;;###autoload
 (defun aider-open-history ()

--- a/aider-file.el
+++ b/aider-file.el
@@ -329,7 +329,7 @@ Otherwise, it's treated as base branch and diff is generated against HEAD."
          (raw-range (read-string "Branch range (base..feature), commit hash, base branch, or staged: " "staged"))
          (diff-params (aider--parse-diff-range raw-range))
          (diff-file-name-part (plist-get diff-params :diff-file-name-part))
-         (diff-file (concat git-root diff-file-name-part ".diff")))
+         (diff-file (expand-file-name (concat diff-file-name-part ".diff") git-root)))
     ;; Generate diff based on type
     (if (eq (plist-get diff-params :type) 'staged)
         (aider--generate-staged-diff diff-file)


### PR DESCRIPTION
It will pull the changes of staged files, as staged.diff, and open it. Run the command second time will review that diff. The idea came from https://github.com/ragnard/gptel-magit/blob/main/gptel-magit.el#L96.

Also refactor the code review function since it has grown very large, with C-c a R (LLM suggest the refactoring strategy and I go ahead to accept it).