### PR TITLE
Feat: Expose aider /copy command as a menu item

### DIFF
--- a/aider-discussion.el
+++ b/aider-discussion.el
@@ -82,7 +82,8 @@ With a prefix argument, calls `aider-general-question` instead."
   "Copy the last assistant message to the clipboard via Aider."
   (interactive)
   (aider--send-command "/copy" t)
-  (message "Last assistant message copied to the clipboard"))
+  ;; (message "Last assistant message copied to the clipboard")
+  )
 
 ;; New function to get command from user and send it prefixed with "/ask ", might be tough for AI at this moment
 ;;;###autoload

--- a/aider-discussion.el
+++ b/aider-discussion.el
@@ -15,41 +15,44 @@
 
 ;; New function to get command from user and send it prefixed with "/ask "
 ;;;###autoload
-(defun aider-ask-question ()
+(defun aider-ask-question (&optional prefix)
   "Ask aider question about specific code.
-Focuses on understanding, analyzing, improving the selected code or function."
-  (interactive)
-  ;; Dispatch to general question if in aider buffer
-  (let* ((function-name (which-function))
-         (region-active (region-active-p))
-         (region-in-function (and region-active function-name))
-         (prompt (cond
-                  (region-in-function (format "Question for the selected region in function '%s': " function-name))
-                  (function-name (format "About function '%s': " function-name))
-                  (region-active "Question for the selected region: ")
-                  (t "Question: ")))
-         (candidate-list '("What kind of question do you have about this code?"
-                           "What is your suggestion on the most important thing to do"
-                          "Carefully review this file and suggest improvements"
-                          "What does this code do? Explain the logic of this code step by step"
-                          "What are the inputs and outputs of this code?"
-                          "Are there any edge cases not handled in this code?"
-                          "How could this code be simplified?"
-                          "What's the time/space complexity of this algorithm?"
-                          "Is there a more efficient way to implement this?"
-                          "What design patterns are used here?"
-                          "How does this code handle errors?"))
-         (raw-question (aider-read-string prompt nil candidate-list))
-         (question (if function-name
-                       (concat prompt raw-question)
-                     raw-question))
-         (region-text (and (region-active-p)
-                           (buffer-substring-no-properties (region-beginning) (region-end))))
-         (question-context (if region-text
-                               (format "%s: %s" question region-text)
-                             question)))
-    (aider-current-file-command-and-switch "/ask " question-context)
-    (message "Question about code sent to Aider")))
+Focuses on understanding, analyzing, improving the selected code or function.
+With a prefix argument, calls `aider-general-question` instead."
+  (interactive "P")
+  (if prefix
+      (aider-general-question)
+    ;; Dispatch to general question if in aider buffer
+    (let* ((function-name (which-function))
+           (region-active (region-active-p))
+           (region-in-function (and region-active function-name))
+           (prompt (cond
+                    (region-in-function (format "Question for the selected region in function '%s': " function-name))
+                    (function-name (format "About function '%s': " function-name))
+                    (region-active "Question for the selected region: ")
+                    (t "Question: ")))
+           (candidate-list '("What kind of question do you have about this code?"
+                             "What is your suggestion on the most important thing to do"
+                            "Carefully review this file and suggest improvements"
+                            "What does this code do? Explain the logic of this code step by step"
+                            "What are the inputs and outputs of this code?"
+                            "Are there any edge cases not handled in this code?"
+                            "How could this code be simplified?"
+                            "What's the time/space complexity of this algorithm?"
+                            "Is there a more efficient way to implement this?"
+                            "What design patterns are used here?"
+                            "How does this code handle errors?"))
+           (raw-question (aider-read-string prompt nil candidate-list))
+           (question (if function-name
+                         (concat prompt raw-question)
+                       raw-question))
+           (region-text (and (region-active-p)
+                             (buffer-substring-no-properties (region-beginning) (region-end))))
+           (question-context (if region-text
+                                 (format "%s: %s" question region-text)
+                               question)))
+      (aider-current-file-command-and-switch "/ask " question-context)
+      (message "Question about code sent to Aider"))))
 
 ;;;###autoload
 (defun aider-general-question ()

--- a/aider-discussion.el
+++ b/aider-discussion.el
@@ -77,9 +77,12 @@ With a prefix argument, calls `aider-general-question` instead."
   (interactive)
   (aider--send-command "go ahead" t))
 
-;; add an interactive function, aider-copy-to-clipboard. It is similar
-;; to aider-go-ahead, but just send command /copy to aider session.
-;; Then show message in mini-buffer: Last assistant message copied to the clipboard
+;;;###autoload
+(defun aider-copy-to-clipboard ()
+  "Copy the last assistant message to the clipboard via Aider."
+  (interactive)
+  (aider--send-command "/copy" t)
+  (message "Last assistant message copied to the clipboard"))
 
 ;; New function to get command from user and send it prefixed with "/ask ", might be tough for AI at this moment
 ;;;###autoload

--- a/aider-discussion.el
+++ b/aider-discussion.el
@@ -77,6 +77,10 @@ With a prefix argument, calls `aider-general-question` instead."
   (interactive)
   (aider--send-command "go ahead" t))
 
+;; add an interactive function, aider-copy-to-clipboard. It is similar
+;; to aider-go-ahead, but just send command /copy to aider session.
+;; Then show message in mini-buffer: Last assistant message copied to the clipboard
+
 ;; New function to get command from user and send it prefixed with "/ask ", might be tough for AI at this moment
 ;;;###autoload
 (defun aider-debug-exception ()

--- a/aider.el
+++ b/aider.el
@@ -117,6 +117,7 @@ Also based on aider LLM benchmark: https://aider.chat/docs/leaderboards/"
     ("q" "Question (C-u no context)" aider-ask-question)
     ("y" "Then Go Ahead" aider-go-ahead)
     ("d" "Code Reading" aider-code-read)
+    ("c" "Copy To Clipboard" aider-copy-to-clipboard)
     ("e" "Debug Exception" aider-debug-exception)
     ("h" "Open History" aider-open-history)
     ("H" "Help (C-u: homepage)" aider-help)

--- a/aider.el
+++ b/aider.el
@@ -114,9 +114,8 @@ Also based on aider LLM benchmark: https://aider.chat/docs/leaderboards/"
     ;; ("c" "Direct Code Change" aider-code-change)
     ]
    ["Discussion"
-    ("q" "Question on Function/Region" aider-ask-question)
+    ("q" "Question (C-u no context)" aider-ask-question)
     ("y" "Then Go Ahead" aider-go-ahead)
-    ("Q" "Question without Context" aider-general-question)
     ("d" "Code Reading" aider-code-read)
     ("e" "Debug Exception" aider-debug-exception)
     ("h" "Open History" aider-open-history)


### PR DESCRIPTION
The command is useful discuss with aider on some code, or ask aider to do trouble shooting. The copied text can be useful as part of the note / investigation report.

Also merge the Question on Function/Region and Question without Context as a single menu item, to release more menu item space.