### PR TITLE
Feat: Add diff-change aider code snippet

### DIFF
--- a/HISTORY.org
+++ b/HISTORY.org
@@ -1,6 +1,10 @@
 
 * Release history
 
+** Main branch change
+
+- Add diff-change aider code snippet, it is a useful pattern to let aider suggest code change given diff as example
+
 ** v0.9.0
 
 - Add aider-add-module function, it will add files with suffix in the module directory to aider session. It will be useful for the whole module level analysis and code change.

--- a/snippets/aider-prompt-mode/create-tests
+++ b/snippets/aider-prompt-mode/create-tests
@@ -1,7 +1,7 @@
 # -*- mode: snippet -*-
-# name: create-tests
-# key: tests
+# name: Create Unit Tests
+# key: unittests
 # contributor: Matic Vertačnik
 # --
-/ask Create two tests for the above function. One that is expected to pass and one that is expected to fail.
+/architect Generate two unit tests for the provided code: one that is expected to pass and one that is expected to fail. Ensure the tests cover both success and error conditions.
 $0

--- a/snippets/aider-prompt-mode/create-unit-tests
+++ b/snippets/aider-prompt-mode/create-unit-tests
@@ -1,6 +1,0 @@
-# -*- mode: snippet -*-
-# name: Create Unit Tests
-# key: unittests
-# contributor: Matic Vertačnik
-# --
-/architect Generate two unit tests for the provided code: one that is expected to pass and one that is expected to fail. Ensure the tests cover both success and error conditions.

--- a/snippets/aider-prompt-mode/diff-change
+++ b/snippets/aider-prompt-mode/diff-change
@@ -9,4 +9,6 @@
 
 /ask Given example changes in $1, Please suggest change for the following request, use english in comment: ${3:change_requirement}
 
+/ask ${4:feedback_prompt}
+
 go ahead

--- a/snippets/aider-prompt-mode/diff-change
+++ b/snippets/aider-prompt-mode/diff-change
@@ -1,0 +1,12 @@
+# -*- mode: snippet -*-
+# name: Suggest Change Given Diff
+# key: diff-change
+# contributor: Kang Tu
+# --
+/read-only ${1:diff_filename.diff}
+
+/add ${2:file_to_change}
+
+/ask Given example changes in $1, Please suggest change for the following request, use english in comment: ${3:change_requirement}
+
+go ahead


### PR DESCRIPTION
An useful pattern of code change with aider.el is:

1. use aider-pull-or-review-diff-file (C-c a v) to pull the diff of a previous change, as a diff file
2. ask aider to suggest change given the change example in that diff file, change made somewhere else but similar to change in that diff file
3. review the change suggestion, give feedback to aider with more /ask command
4. go ahead to accept the suggestion and let aider make the change.

This PR add diff-change aider code snippet for this pattern. It can be used in aider prompt file or other file after active aider-prompt-mode, use C-n to run each line of command there.