### PR TITLE
chore: rely on stable version (0.9.0) of transient

### DIFF
--- a/HISTORY.org
+++ b/HISTORY.org
@@ -10,7 +10,7 @@
   - https://github.com/tninja/aider.el/issues/163, found by Spike-Leung and markokocic
   - Fixed by Spike-Leung in https://github.com/tninja/aider.el/pull/164
     - It require latest >= transient-20250520.1040
-    - [ ] will update transient version dependency to 0.9.0 after it got released
+    - [X] will update transient version dependency to 0.9.0 after it got released
 - Better align aider-transient-menu-2col, by Spike-Leung
 - Fix error during redisplay (jit-lock-function) when working with comint mode
   - https://github.com/tninja/aider.el/issues/159 by velimir

--- a/README.org
+++ b/README.org
@@ -55,7 +55,7 @@
 
 ** Vanilla Emacs Installation
 - [[https://aider.chat/docs/install.html][Install aider]]
-- Install the emacs dependency library [[https://github.com/magit/transient][Transient]] (version >= 20250520.1040), [[https://github.com/magit/magit][Magit]], and [[https://jblevins.org/projects/markdown-mode/][Markdown-mode]] using your package manager.
+- Install the emacs dependency library [[https://github.com/magit/transient][Transient]] (version >= 0.9.0), [[https://github.com/magit/magit][Magit]], and [[https://jblevins.org/projects/markdown-mode/][Markdown-mode]] using your package manager.
 - Install aider.el with the following instruction:
 
 *** With Melpa + package-install (recommended)
@@ -315,7 +315,7 @@ If you used installed aider.el through melpa and package-install, just need to ~
 * FAQ
 
 - transient-define-group undefined error:
-  - Please install latest transient package. The version need to be >= 20250520.1040, so that it have [[https://github.com/magit/transient/blob/main/CHANGELOG#v090----unreleased][transient-define-group macro]]
+  - Please install latest stable transient package (version >= 0.9.0), so that it have [[https://github.com/magit/transient/blob/main/CHANGELOG#v090----unreleased][transient-define-group macro]]
 
 - How to review / accept the code change? 
   - Comparing to cursor, aider have a different way to do that. [[https://github.com/tninja/aider.el/issues/98][Discussion]]

--- a/README.zh-cn.org
+++ b/README.zh-cn.org
@@ -49,7 +49,7 @@
 
 ** 原生 Emacs 安装
 - [[https://aider.chat/docs/install.html][安装 aider]]
-- 使用您的包管理器安装 Emacs 依赖库 [[https://github.com/magit/transient][Transient]] (版本 >= 20250520.1040)、[[https://github.com/magit/magit][Magit]] 和 [[https://jblevins.org/projects/markdown-mode/][Markdown-mode]]。
+- 使用您的包管理器安装 Emacs 依赖库 [[https://github.com/magit/transient][Transient]] (版本 >= 0.9.0)、[[https://github.com/magit/magit][Magit]] 和 [[https://jblevins.org/projects/markdown-mode/][Markdown-mode]]。
 - 使用以下代码安装 aider.el：
 
 *** With Melpa + package-install (推荐)
@@ -304,7 +304,7 @@ Helm 为命令历史提示启用模糊搜索功能。由于我们很可能会使
 * 常见问题
 
 - transient-define-group undefined error:
-  - 请安装最新的 transient 包。版本需要 >= 20250520.1040，以便它具有 [[https://github.com/magit/transient/blob/main/CHANGELOG#v090----unreleased][transient-define-group 宏]]
+  - 请安装最新的 transient 包。版本需要 >= 0.9.0，以便它具有 [[https://github.com/magit/transient/blob/main/CHANGELOG#v090----unreleased][transient-define-group 宏]]
 
 - 如何审查/接受代码更改？
   - 与 cursor 相比，aider 有不同的方式来处理代码更改。[[https://github.com/tninja/aider.el/issues/98][讨论]]

--- a/aider.el
+++ b/aider.el
@@ -2,7 +2,7 @@
 
 ;; Author: Kang Tu <tninja@gmail.com>
 ;; Version: 0.10.0
-;; Package-Requires: ((emacs "26.1") (transient "20250520.1040") (magit "2.1.0") (markdown-mode "2.5") (s "1.13.0"))
+;; Package-Requires: ((emacs "26.1") (transient "0.9.0") (magit "2.1.0") (markdown-mode "2.5") (s "1.13.0"))
 ;; Keywords: ai gpt sonnet llm aider gemini-pro deepseek ai-assisted-coding
 ;; URL: https://github.com/tninja/aider.el
 ;; SPDX-License-Identifier: Apache-2.0


### PR DESCRIPTION
Given upgrading of https://github.com/magit/transient/blob/main/CHANGELOG#v090----2025-06-01

The version contains transient-define-group macro

cc @Spike-Leung 