### PR TITLE
feat: Add option for branch-specific aider buffers

### DIFF
--- a/HISTORY.org
+++ b/HISTORY.org
@@ -4,6 +4,9 @@
 ** Main branch
 
 - Add support for dropping file under cursor in aider comint buffer, given discussion in https://github.com/tninja/aider.el/issues/179
+- Multiple chats for the same repository. 
+  - To turn on this feature, ~(setq aider-use-branch-specific-buffers t)~
+  - *If we want to switch to work on a different feature, we switch git branch, and it will map to a corresponding aider session.* The aider session name pattern would be ~aider:<path-to-git-repo>:branch-name~ 
 
 ** v0.11.0
 

--- a/README.org
+++ b/README.org
@@ -193,6 +193,11 @@ If you used installed aider.el through melpa and package-install, just need to ~
 - By parsing .aider.input.history
 - Use ctrl + up / down key to scroll, alt + r to search
 
+** Multiple chats for the same repository
+
+- To turn on this feature, ~(setq aider-use-branch-specific-buffers t)~
+- *If we want to switch to work on a different feature, we switch git branch, and it will map to a corresponding aider session.* The aider session name pattern would be ~aider:<path-to-git-repo>:branch-name~ 
+
 * Frequently used features
 
 *** Aider session management

--- a/aider-core.el
+++ b/aider-core.el
@@ -266,7 +266,7 @@ Format: *aider:<git-repo-path>[:<branch-name>]*."
             (format "*aider:%s:%s*" git-repo-path-true branch-name)
           ;; Fallback: branch name not found or empty
           (progn
-            (message "Aider: Could not determine git branch for '%s', or branch name is empty. Using default git repo buffer name." git-repo-path-true)
+            (warning "Aider: Could not determine git branch for '%s', or branch name is empty. Using default git repo buffer name." git-repo-path-true)
             (format "*aider:%s*" git-repo-path-true))))
     ;; aider-use-branch-specific-buffers is nil
     (format "*aider:%s*" git-repo-path-true)))


### PR DESCRIPTION
Addressing https://github.com/tninja/aider.el/issues/177, to support multiple chats for the same repository.

The way in this PR, is to create git repo + feature branch specific aider session. **If we want to switch to work on a different feature, we switch git branch, and it will map to a corresponding aider session.** The aider session name pattern would be `*aider:<path-to-git-repo>:branch-name* `