### PR TITLE
Feat: /drop command file completion only list files been /add or /read-only

### DIFF
--- a/HISTORY.org
+++ b/HISTORY.org
@@ -1,6 +1,10 @@
 
 * Release history
 
+** Main branch change
+
+- file completion for /drop only list added files
+
 ** v0.11.1
 
 - Add support for dropping file under cursor in aider comint buffer, given discussion in https://github.com/tninja/aider.el/issues/179

--- a/HISTORY.org
+++ b/HISTORY.org
@@ -3,7 +3,7 @@
 
 ** Main branch change
 
-- file completion for /drop only list added files
+- file completion for /drop only list added files, addressing https://github.com/tninja/aider.el/issues/179
 
 ** v0.11.1
 

--- a/aider-core.el
+++ b/aider-core.el
@@ -472,15 +472,15 @@ invoke `aider-prompt-insert-file-path`."
   "Parse the Aider comint buffer to find the list of currently added files.
 Searches upwards from the last Aider prompt (e.g., '>') until a blank line.
 Removes trailing \" (read only)\" from file names."
-  (intreactive)
+  (interactive)
   (let ((aider-buf (get-buffer (aider-buffer-name)))
         (file-list '())) ; Initialize file-list to nil (empty list)
     (when aider-buf
       (with-current-buffer aider-buf
         (save-excursion
           (goto-char (point-max))
-          ;; Search backward for the last line starting with ">" or ">>"
-          (if (re-search-backward "^\\(>\\|>\\)>" nil t)
+          ;; Search backward for the last line starting with ">"
+          (if (re-search-backward "^>" nil t)
               (progn
                 ;; Move to the line above the prompt line
                 (forward-line -1)

--- a/aider-core.el
+++ b/aider-core.el
@@ -472,6 +472,7 @@ invoke `aider-prompt-insert-file-path`."
   "Parse the Aider comint buffer to find the list of currently added files.
 Searches upwards from the last Aider prompt (e.g., '>') until a blank line.
 Removes trailing \" (read only)\" from file names."
+  (intreactive)
   (let ((aider-buf (get-buffer (aider-buffer-name)))
         (file-list '())) ; Initialize file-list to nil (empty list)
     (when aider-buf

--- a/aider-core.el
+++ b/aider-core.el
@@ -158,6 +158,7 @@ Inherits from `comint-mode' with some Aider-specific customizations.
   (add-hook 'post-self-insert-hook #'aider-core--auto-trigger-command-completion nil t)
   ;; Automatically trigger file path insertion for file-related commands
   (add-hook 'post-self-insert-hook #'aider-core--auto-trigger-add-file-path-insertion nil t)
+  (add-hook 'post-self-insert-hook #'aider-core--auto-trigger-drop-file-path-insertion nil t)
   (add-hook 'post-self-insert-hook #'aider-core--auto-trigger-insert-prompt nil t)
   ;; Load history from .aider.input.history if available
   (condition-case err ; catch any error during history loading

--- a/aider-core.el
+++ b/aider-core.el
@@ -468,6 +468,12 @@ invoke `aider-prompt-insert-file-path`."
       (when (string-match-p "^[ \t]*\\(/add\\|/read-only\\|/drop\\) $" line-content)
         (aider-prompt-insert-file-path)))))
 
+;; add a function, aider-core--parse-added-file-list. It will check
+;; the aider comint buffer (example, aider-comint-session.txt)
+;; from the very bottom line with > character
+;; and look above. get all lines above till a space line, remove
+;; trailing " (read only)" of each line, and return the list
+
 ;;;###autoload
 (defun aider-core-insert-prompt ()
   "Get user input via `aider-read-string` and insert it at point."

--- a/aider-core.el
+++ b/aider-core.el
@@ -482,9 +482,16 @@ invoke `aider-prompt-insert-add-file-path`."
       (when (string-match-p "^[ \t]*/drop $" line-content)
         (aider-prompt-insert-drop-file-path)))))
 
-;; add function aider-prompt-insert-drop-file-path. It will call
-;; aider-core--parse-added-file-list to get candidate list, use
-;; completing-read to get the one choosed, and insert it under cursor
+(defun aider-prompt-insert-drop-file-path ()
+  "Prompt for a file to drop from the list of added files and insert its path."
+  (interactive)
+  (let ((candidate-files (aider-core--parse-added-file-list)))
+    (if candidate-files
+        (let ((file-to-drop (completing-read "Drop file: " candidate-files nil t nil)))
+          ;; Check if a file was actually selected and it's not an empty string
+          (when (and file-to-drop (not (string-empty-p file-to-drop)))
+            (insert file-to-drop)))
+      (message "No files currently added to Aider to drop."))))
 
 (defun aider-core--parse-added-file-list ()
   "Parse the Aider comint buffer to find the list of currently added files.

--- a/aider-core.el
+++ b/aider-core.el
@@ -473,7 +473,7 @@ invoke `aider-prompt-insert-add-file-path`."
   "Automatically trigger file path insertion in aider buffer.
 If the current line matches one of the file-related commands
 followed by a space, and the cursor is at the end of the line,
-invoke `aider-prompt-insert-add-file-path`."
+invoke `aider-prompt-insert-drop-file-path`."
   (when (and (not (minibufferp))
              (not (bolp))
              (eq (char-before) ?\s)  ; Check if last char is space

--- a/aider-prompt-mode.el
+++ b/aider-prompt-mode.el
@@ -33,7 +33,7 @@ This is the file name without path."
     (define-key map (kbd "C-c C-c") #'aider-send-block-or-region)
     (define-key map (kbd "C-c C-b") #'aider-send-block-by-line) ;; considering retire this since C-u C-c C-n will do same thing
     (define-key map (kbd "C-c C-z") #'aider-switch-to-buffer)
-    (define-key map (kbd "C-c C-f") #'aider-prompt-insert-file-path)
+    (define-key map (kbd "C-c C-f") #'aider-prompt-insert-add-file-path)
     (define-key map (kbd "C-c C-i") #'aider-core-insert-prompt)
     (define-key map (kbd "C-c C-y") #'aider-prompt-cycle-file-command)
     map)
@@ -288,7 +288,8 @@ Special commands:
   (add-hook 'completion-at-point-functions #'aider-core--command-completion nil t)
   (add-hook 'post-self-insert-hook #'aider-core--auto-trigger-command-completion nil t)
   ;; Automatically trigger file path insertion for file-related commands
-  (add-hook 'post-self-insert-hook #'aider-core--auto-trigger-file-path-insertion nil t)
+  (add-hook 'post-self-insert-hook #'aider-core--auto-trigger-add-file-path-insertion nil t)
+  (add-hook 'post-self-insert-hook #'aider-core--auto-trigger-drop-file-path-insertion nil t)
   ;; Bind space key to aider-core-insert-prompt when evil package is available
   (add-hook 'aider-prompt-mode-hook
             (lambda ()


### PR DESCRIPTION
Resolve https://github.com/tninja/aider.el/issues/179, cc @Spike-Leung 

Following screenshot show completion in aider-comint-session.

![Screenshot from 2025-06-06 20-49-56](https://github.com/user-attachments/assets/500a0b6d-000a-4750-9c9a-2df2801fd9d7)

Same completion will also be triggered from aider prompt file.