### PR TITLE
Fix: Do not run following commands if aider--send-command failed.

### DIFF
--- a/README.org
+++ b/README.org
@@ -12,13 +12,7 @@
 
 - [[#introduction][Introduction]]
 - [[#installation][Installation]]
-  - [[#vanilla-emacs-installation][Vanilla Emacs Installation]]
-  - [[#doom-installation-and-configuration][Doom Installation and Configuration]]
-  - [[#helm-support][Helm Support]]
-- [[#recent-new-features][Recent New Features]]
 - [[#most-used-features-integrated-into-the-aider-menu][Most used features (integrated into the aider menu)]]
-- [[#cons-of-aider.el][Cons of aider.el]]
-- [[#be-careful-about-ai-generated-code][Be careful about AI generated code]]
 - [[#faq][FAQ]]
 - [[#future-work][Future work]]
 - [[#other-emacs-ai-coding-tool][Other Emacs AI coding tool]]
@@ -175,7 +169,7 @@ If you used installed aider.el through melpa and package-install, just need to ~
 
 *** [[./appendix.org#prompt-snippets][Prompt Snippets]]
 
-* Cons of aider.el
+* [[./appendix.org#cons-of-aiderel][Cons of aider.el]]
 
 - The current implementation is using comint to host aider session, a classic CLI interactive solution used in emacs, However, comint-mode initially _doesn't have the advance features such as codeblock color rendering and file tracking_ from aider.
   - *color rendering from markdown-mode.el is applied in aider comint session buffer it and largely improved this*.
@@ -285,6 +279,9 @@ The following books introduce how to use AI to assist programming and potentiall
 
 - Package depends on this
   - [[https://github.com/localredhead/ob-aider.el][ob-aider.el]]: Org Babel functions for Aider.el integration
+
+- Other tools
+  - [[https://github.com/stevemolitor/claude-code.el][claude-code.el]]
 
 * Contributing
 

--- a/README.org
+++ b/README.org
@@ -107,7 +107,7 @@ Helm enables fuzzy searching functionality for command history prompts. Since it
 
 If you used installed aider.el through melpa and package-install, just need to ~(require 'aider-helm)~
 
-** [[./appendix.org::*Other ways to install aider.el][Other ways to install aider.el]]
+** [[./appendix.org#other-ways-to-install-aiderel][Other ways to install aider.el]]
 
 * Frequently used features
 

--- a/README.org
+++ b/README.org
@@ -46,7 +46,8 @@
 
 - Besides of that, aider.el focus on simplicity. It has much less configurations (transparent to aider config), simplified menu.
 
-- Aider.el is under active development. [[./HISTORY.org][Recent change history]]
+- Aider.el is under active development. [[./HISTORY.org][Recent change history]],  [[./appendix.org#recent-new-features][Recent new features]]
+
 
 [[file:./transient_menu.png]]
 
@@ -172,9 +173,7 @@ If you used installed aider.el through melpa and package-install, just need to ~
   - Use ~subtree-only <dir>~ to start aider session in a sub-tree, where <dir> is the directory to start the session.
   - This is useful when you want to work on a sub-directory of a large mono repo, and don't want to wait for aider to scan the entire repo.
 
-* [[./appendix.org#prompt-snippets][Prompt Snippets]]
-
-* [[./appendix.org#recent-new-features][Recent New Features]]
+*** [[./appendix.org#prompt-snippets][Prompt Snippets]]
 
 * Cons of aider.el
 

--- a/README.org
+++ b/README.org
@@ -12,7 +12,7 @@
 
 - [[#introduction][Introduction]]
 - [[#installation][Installation]]
-- [[#most-used-features-integrated-into-the-aider-menu][Most used features (integrated into the aider menu)]]
+- [[#frequently-used-features][Most used features (integrated into the aider menu)]]
 - [[#faq][FAQ]]
 - [[#future-work][Future work]]
 - [[#other-emacs-ai-coding-tool][Other Emacs AI coding tool]]

--- a/README.org
+++ b/README.org
@@ -171,11 +171,6 @@ If you used installed aider.el through melpa and package-install, just need to ~
 
 * [[./appendix.org#cons-of-aiderel][Cons of aider.el]]
 
-- The current implementation is using comint to host aider session, a classic CLI interactive solution used in emacs, However, comint-mode initially _doesn't have the advance features such as codeblock color rendering and file tracking_ from aider.
-  - *color rendering from markdown-mode.el is applied in aider comint session buffer it and largely improved this*.
-  - Without file tracking, aider.el cannot do [[https://aider.chat/docs/usage/watch.html#ai-comments][AI comments]]. *The work around we provided is ~aider-implement-todo~*, It use architect command to ask aider to implement comment under cursor by default. I constantly use this feature and feel it is OK.
-  - [[https://github.com/akermu/emacs-libvterm][vterm based interactive session]] can make the aider session close to the user experience of using aider in terminal. Considering that comint based solution is battle tested for many years and it is very stable, and long term maintainability of the project, aider.el only use comint session based solution. 
-
 * [[./appendix.org#be-careful-about-ai-generated-code][Be careful about AI generated code]]
 
 * FAQ

--- a/README.org
+++ b/README.org
@@ -107,7 +107,7 @@ Helm enables fuzzy searching functionality for command history prompts. Since it
 
 If you used installed aider.el through melpa and package-install, just need to ~(require 'aider-helm)~
 
-** [[file:appendix.org::*Other ways to install aider.el][Other ways to install aider.el]]
+** [[./appendix.org::*Other ways to install aider.el][Other ways to install aider.el]]
 
 * Frequently used features
 
@@ -172,9 +172,9 @@ If you used installed aider.el through melpa and package-install, just need to ~
   - Use ~subtree-only <dir>~ to start aider session in a sub-tree, where <dir> is the directory to start the session.
   - This is useful when you want to work on a sub-directory of a large mono repo, and don't want to wait for aider to scan the entire repo.
 
-* [[file:appendix.org::*\[\[./snippets/aider-prompt-mode\]\[Prompt Snippets\]\]][Prompt Snippets]]
+* [[./appendix.org::*\[\[./snippets/aider-prompt-mode\]\[Prompt Snippets\]\]][Prompt Snippets]]
 
-* [[file:appendix.org::*Recent New Features][Recent New Features]]
+* [[./appendix.org::*Recent New Features][Recent New Features]]
 
 * Cons of aider.el
 

--- a/README.org
+++ b/README.org
@@ -172,9 +172,9 @@ If you used installed aider.el through melpa and package-install, just need to ~
   - Use ~subtree-only <dir>~ to start aider session in a sub-tree, where <dir> is the directory to start the session.
   - This is useful when you want to work on a sub-directory of a large mono repo, and don't want to wait for aider to scan the entire repo.
 
-* [[./appendix.org::*\[\[./snippets/aider-prompt-mode\]\[Prompt Snippets\]\]][Prompt Snippets]]
+* [[./appendix.org#prompt-snippets][Prompt Snippets]]
 
-* [[./appendix.org::*Recent New Features][Recent New Features]]
+* [[./appendix.org#recent-new-features][Recent New Features]]
 
 * Cons of aider.el
 
@@ -183,7 +183,7 @@ If you used installed aider.el through melpa and package-install, just need to ~
   - Without file tracking, aider.el cannot do [[https://aider.chat/docs/usage/watch.html#ai-comments][AI comments]]. *The work around we provided is ~aider-implement-todo~*, It use architect command to ask aider to implement comment under cursor by default. I constantly use this feature and feel it is OK.
   - [[https://github.com/akermu/emacs-libvterm][vterm based interactive session]] can make the aider session close to the user experience of using aider in terminal. Considering that comint based solution is battle tested for many years and it is very stable, and long term maintainability of the project, aider.el only use comint session based solution. 
 
-* [[./appendix.org::*Be careful about AI generated code][Be careful about AI generated code]]
+* [[./appendix.org#be-careful-about-ai-generated-code][Be careful about AI generated code]]
 
 * FAQ
 

--- a/README.org
+++ b/README.org
@@ -54,12 +54,10 @@
 
 - Emacs need to be >= 26.1
 
-** Vanilla Emacs Installation
+** Melpa + package-install (recommended)
 - [[https://aider.chat/docs/install.html][Install aider]]
 - Install the emacs dependency library [[https://github.com/magit/transient][Transient]] (version >= 0.9.0), [[https://github.com/magit/magit][Magit]], and [[https://jblevins.org/projects/markdown-mode/][Markdown-mode]] using your package manager.
 - Install aider.el with the following instruction:
-
-*** With Melpa + package-install (recommended)
 
 Enable installation of packages from MELPA by adding an entry to package-archives after (require 'package) and before the call to package-initialize in your init.el or .emacs file: 
 
@@ -103,91 +101,13 @@ Enable installation of packages from MELPA by adding an entry to package-archive
 
 - The example models: sonnet, gemini, o4-mini, they charge money, and you need to ask for api key add fund to your api account firstly
 
-*** With [[https://www.gnu.org/software/emacs/manual/html_node/emacs/Fetching-Package-Sources.html#:~:text=One%20way%20to%20do%20this,just%20like%20any%20other%20package.][package-vc-install]] (Emacs 30+ built-in)
-- Install aider.el by running the following code within Emacs
-  - You'll need to manually install the required packages, such as [[https://github.com/magit/transient][Transient]], [[https://github.com/magit/magit][Magit]], and helm.
-
-#+BEGIN_SRC emacs-lisp
-(package-vc-install '(aider :url "https://github.com/tninja/aider.el"))
-#+END_SRC
-
-The config part is as same as above one
-
-*** With [[https://github.com/radian-software/straight.el?tab=readme-ov-file][Straight]]
-If you have Straight installed
-#+BEGIN_SRC emacs-lisp
-  (use-package aider
-    :straight (:host github :repo "tninja/aider.el")
-    :config
-    ;; rest of configs
-    )
-#+END_SRC
-
-** Doom Installation and Configuration
-
-- Add the following code to your doom/packages.el
-
-#+BEGIN_SRC emacs-lisp
-(package! aider :recipe (:host github :repo "tninja/aider.el" ))
-#+END_SRC
-
-- Adjust and add the following code to your doom/config.el
-
-#+BEGIN_SRC emacs-lisp
-(use-package aider
-  :config
-  (setq aider-args '("--model" "sonnet"))
-  (require 'aider-doom))
-#+END_SRC
-
-The aider prefix is ~A~.
-
-- Start and open the aider buffer: =[SPC] A p a=
-- Add the current file with =[SPC] A f f=
-- Reset the aider session with =[SPC] A p s=
-[[file:./doom_menus.png]]
-
-- *However, transient menu is more recommended than doom menu*, cause I constantly use that one so it is better maintained.
-  - Anyone want to contribute to doom menu, feel free to help on it. Thanks.
- 
 ** Helm Support
 
-Helm enables fuzzy searching functionality for command history prompts. Since it is very possible that we use prompt written before, it could potentially save lots of time typing. *This plugin is highly recommended if you are OK with helm*.
+Helm enables fuzzy searching functionality for command history prompts. Since it is very possible that we use prompt written before, it could potentially save lots of time typing. *This plugin is recommended if you use helm*.
 
 If you used installed aider.el through melpa and package-install, just need to ~(require 'aider-helm)~
 
-* Recent New Features
-
-** Software Planning Discussion
-
-- aider-software-planning :: use Software Planning using code from the mcp server (~C-c a P~)
-  - Software Planning is a mcp server designed to facilitate software development planning through an interactive, structured approach. It helps break down complex software projects into manageable tasks.
-
-** Let aider to fix the errors reported by flycheck
-
-- aider-flycheck-fix-errors-in-scope :: Flycheck output will be sent to aider as context to fix the error. It support:
-  - current function
-  - selected region
-  - whole file (C-u)
-
-** File / repo change history analysis with magit-blame and magit-log integration 
-
-- aider-magit-blame-analyze :: combines magit-blame with AI analysis to help understand code history and reasoning behind changes for a file or selected region (~C-c a e~).
-- aider-aider-magit-log-analyze :: integrates magit-log with AI analysis to provide insights into commit history and evolution of the repository (~C-u C-c a e~).
-
-** Bootstrap New File 
-
-- aider-bootstrap :: Bootstrap common code / doc structures (Code, Config, Doc, Slides, etc, ~C-c a B~)
-
-** Aider-comint-session be able to scroll up / search the prompt across sessions
-
-- By parsing .aider.input.history
-- Use ctrl + up / down key to scroll, alt + r to search
-
-** Multiple chats for the same repository
-
-- To turn on this feature, ~(setq aider-use-branch-specific-buffers t)~
-- *If we want to switch to work on a different feature, we switch git branch, and it will map to a corresponding aider session.* The aider session name pattern would be ~aider:<path-to-git-repo>:branch-name~ 
+** [[file:appendix.org::*Other ways to install aider.el][Other ways to install aider.el]]
 
 * Frequently used features
 
@@ -228,7 +148,13 @@ If you used installed aider.el through melpa and package-install, just need to ~
   - aider-code-read :: Choose the method from the book, [[https://www.amazon.com/Code-Reading-Open-Source-Perspective/dp/0201799405/ref=sr_1_1?crid=39HOB4975Y8LZ&dib=eyJ2IjoiMSJ9.fjkryt7JHaLWMQ5xuSPTED-gJR52Wqh448RQ3TrsTPYAFNpx--gA-mTNGqRQqebb.rnvw74YGEJXCRRe0UIwUSwAaeEngg0MpraxcTOBRn5Q&dib_tag=se&keywords=Code+Reading%3A+The+Open+Source+Perspective&qid=1744517167&s=books&sprefix=code+reading+the+open+source+perspective%2Cstripbooks%2C254&sr=1-1][Code Reading: The Open Source Perspective, by Diomidis Spinellis]], to analyze the region / function / file / module. 
   - aider-start-software-planning :: Start an interactive software planning discussion session with Aider, through a question-based sequential thinking process.
 
-*** Aider prompt file
+*** Inside comint buffer
+
+- / key to trigger aider command completion
+- file path completion will be triggered automatically after certain command
+- use TAB key to enter prompt from mini-buffer, or helm with completion
+
+*** Aider prompt file - Good place to write and organize prompt
 
 - Syntax highlight, aider command completion, file path completion supported
 
@@ -246,24 +172,9 @@ If you used installed aider.el through melpa and package-install, just need to ~
   - Use ~subtree-only <dir>~ to start aider session in a sub-tree, where <dir> is the directory to start the session.
   - This is useful when you want to work on a sub-directory of a large mono repo, and don't want to wait for aider to scan the entire repo.
 
-**** [[./snippets/aider-prompt-mode][Prompt Snippets]]
+* [[file:appendix.org::*\[\[./snippets/aider-prompt-mode\]\[Prompt Snippets\]\]][Prompt Snippets]]
 
-- Prompts for aider might share similar structure. Yasnippet can be used to help reusing these prompts.
-
-- Aider prompt file now support yasnippet. Current snippets came from [[https://www.reddit.com/r/ClaudeAI/comments/1f0ya1t/i_used_claude_to_write_an_sop_for_using_claude/?utm_source=share&utm_medium=web3x&utm_name=web3xcss&utm_term=1&utm_content=share_button][this reddit post]], [[https://www.reddit.com/r/ChatGPTCoding/comments/1f51y8s/a_collection_of_prompts_for_generating_high/][another reddit post]], and a [[https://github.com/PickleBoxer/dev-chatgpt-prompts][git repo]].
-
-- You can use
-  - ~M-x yas-describe-tables~ to see the available snippets
-  - ~M-x yas-insert-snippet~ to insert a snippet.
-  - ~M-x yas-expand~ to expand the snippet under cursor.
-
-- Welcome to add more snippets / improve existing snippets in the [[./snippets/aider-prompt-mode][snippets folder]]!
-
-*** Inside comint buffer
-
-- / key to trigger aider command completion
-- file path completion will be triggered automatically after certain command
-- use TAB key to enter prompt from mini-buffer, or helm with completion
+* [[file:appendix.org::*Recent New Features][Recent New Features]]
 
 * Cons of aider.el
 
@@ -272,54 +183,7 @@ If you used installed aider.el through melpa and package-install, just need to ~
   - Without file tracking, aider.el cannot do [[https://aider.chat/docs/usage/watch.html#ai-comments][AI comments]]. *The work around we provided is ~aider-implement-todo~*, It use architect command to ask aider to implement comment under cursor by default. I constantly use this feature and feel it is OK.
   - [[https://github.com/akermu/emacs-libvterm][vterm based interactive session]] can make the aider session close to the user experience of using aider in terminal. Considering that comint based solution is battle tested for many years and it is very stable, and long term maintainability of the project, aider.el only use comint session based solution. 
 
-* Be careful about AI generated code
-
-- Thanks to LLM. It is so easy to generate bunch of code with AI. But generating code doesn't complete the work. 
-  - There might be potential bug hidden inside. It need to be verified that the feature work as expected, and code change didn't break existing features.
-  - Developer might be lack of understanding of AI generated code. If there is too many code developer don't quite understand, the project could be out of control, like this:
-
-#+BEGIN_HTML
-  <img src="https://i.redd.it/puzjerkgcfqe1.jpeg" width="300" />
-#+END_HTML
-
-- *Unit-test can be useful on both of the above concern*. And aider can help writing unit tests.
-  - The AI generated test need to be manually checked / fixed. But generally test code is easier to understand.
-  - Running the unit-tests can help verifying the correctness / identifying the bug of code. It also help developer better understanding how the AI generated code work, and it can give developer more confidence on the new code.
-
-** A weak [[https://en.wikipedia.org/wiki/Test-driven_development][TDD]] style AI programming workflow
-
-1. *Implement or modify code*
-   - For existing code: Use ~aider-function-or-region-refactor~ with cursor in function or on selected region
-   - For new code: Use ~aider-implement-todo~ on TODO comments
-   
-   *Example of adding new code*:
-   
-   With cursor on this comment:
-   #+BEGIN_SRC python :eval never
-   # TODO: Implement a function that checks if a number is prime
-   #+END_SRC
-   
-   Running ~aider-implement-todo~ might generate:
-   #+BEGIN_SRC python :eval never
-   def is_prime(n):
-       if n <= 1:
-           return False
-       for i in range(2, int(n ** 0.5) + 1):
-           if n % i == 0:
-               return False
-       return True
-   #+END_SRC
-   
-   If suggestions aren't satisfactory, use ~Ask Question~ for refinements and ~Go Ahead~ to confirm changes.
-
-2. *Generate tests*: Validate your implementation with ~aider-write-unit-test~. Do run the test to validate code behavior.
-   - ~aider-write-unit-test~ can be used to write unit-test before the code is implemented, just call the function in the unit-test class. I tried it with leetcode problems and it works pretty well.
-
-3. *Refine code and tests*: Further refactor as needed using additional prompts or manual adjustments. ~aider-refactor-book-method~ have couple of refactoring techniques from [[https://www.amazon.com/Refactoring-Improving-Existing-Addison-Wesley-Signature/dp/0134757599/ref=asc_df_0134757599?mcid=2eb8b1a5039a3b7c889ee081fc2132e0&hvocijid=16400341203663661896-0134757599-&hvexpln=73&tag=hyprod-20&linkCode=df0&hvadid=721245378154&hvpos=&hvnetw=g&hvrand=16400341203663661896&hvpone=&hvptwo=&hvqmt=&hvdev=c&hvdvcmdl=&hvlocint=&hvlocphy=9032161&hvtargid=pla-2281435180458&psc=1][Martin Flower's Refactoring book]]
-
-4. Goto 1
-
-- Alternatively, if you prefer strong TDD practice, you might want to try ~aider-tdd-cycle~, it will follow strict red-green-refactor cycle.
+* [[./appendix.org::*Be careful about AI generated code][Be careful about AI generated code]]
 
 * FAQ
 

--- a/aider-agile.el
+++ b/aider-agile.el
@@ -163,9 +163,9 @@ If TDD-MODE is non-nil, adds TDD constraints to the instruction."
                               region-text)
                     (format "\"%s\"" final-instruction)))
          (message-suffix (if tdd-mode " during TDD refactor stage" "")))
-    (aider-current-file-command-and-switch "/architect " command)
-    (message "%s refactoring request sent to Aider%s. After code refactored, better to re-run unit-tests."
-             selected-technique message-suffix)))
+    (when (aider-current-file-command-and-switch "/architect " command)
+      (message "%s refactoring request sent to Aider%s. After code refactored, better to re-run unit-tests."
+               selected-technique message-suffix))))
 
 (defun aider--handle-ask-llm-suggestion (context tdd-mode)
   "Handle the case where the user asks the LLM for a refactoring suggestion.
@@ -193,10 +193,10 @@ If TDD-MODE is non-nil, adds TDD constraints to the prompt."
          (prompt (concat base-prompt tdd-constraint))
          (message-suffix (if tdd-mode " during TDD refactor stage" "")))
     ;; Send the prompt using the /ask command
-    (aider-current-file-command-and-switch "/ask " prompt)
-    ;; Inform the user
-    (message "Requesting refactoring suggestion from Aider%s. If you are happy with the suggestion, use 'go ahead' to accept the change"
-             message-suffix)))
+    (when (aider-current-file-command-and-switch "/ask " prompt)
+      ;; Inform the user
+      (message "Requesting refactoring suggestion from Aider%s. If you are happy with the suggestion, use 'go ahead' to accept the change"
+               message-suffix))))
 
 ;;;###autoload
 (defun aider-refactor-book-method (&optional tdd-mode)

--- a/aider-bootstrap.el
+++ b/aider-bootstrap.el
@@ -275,10 +275,11 @@ For each file, provide a brief description of its purpose and basic content."
             (unless (file-exists-p note-filename)
               (error "Note file '%s' does not exist. Cannot update" note-filename))
             ;; Add the existing note file to Aider's context
-            (aider--send-command (format "/add %s" (shell-quote-argument note-filename)) t)))
+            (unless (aider--send-command (format "/add %s" (shell-quote-argument note-filename)) t)
+              (error "Failed to add note file to Aider context"))))
       ;; Send the main architect command
-      (aider--send-command command t)
-      (message "Contextual note generation/update request sent to Aider for '%s'." (file-name-nondirectory note-filename)))))
+      (when (aider--send-command command t)
+        (message "Contextual note generation/update request sent to Aider for '%s'." (file-name-nondirectory note-filename))))))
 
 (defun aider--bootstrap-general-plan ()
   "Generate a general plan outline for various purposes."

--- a/aider-code-change.el
+++ b/aider-code-change.el
@@ -98,7 +98,7 @@ Otherwise, refactor the function under cursor."
       (when (aider-current-file-command-and-switch
              "/architect "
              (concat (format "refactor %s: " function-name) instruction))
-        (message "Code change request sent to Aider")))))))
+        (message "Code change request sent to Aider"))))))))
 
 (defun aider--is-comment-line (line)
   "Check if LINE is a comment line based on current buffer's comment syntax.
@@ -303,7 +303,7 @@ This command requires the `flycheck` package to be installed and available."
               (when (and edited-prompt (not (string-blank-p edited-prompt)))
                 (aider-add-current-file)
                 (when (aider--send-command (concat "/architect " edited-prompt) t)
-                  (message "Sent request to Aider to fix %d Flycheck error(s) in %s." (length errors-in-scope) scope-description)))))))))
+                  (message "Sent request to Aider to fix %d Flycheck error(s) in %s." (length errors-in-scope) scope-description))))))))))
 
 (provide 'aider-code-change)
 

--- a/aider-code-change.el
+++ b/aider-code-change.el
@@ -95,10 +95,10 @@ Otherwise, refactor the function under cursor."
         (aider--send-command command t)))
      ;; Function case
      (function-name
-      (aider-current-file-command-and-switch
-       "/architect "
-       (concat (format "refactor %s: " function-name) instruction))))
-      (message "Code change request sent to Aider")))))
+      (when (aider-current-file-command-and-switch
+             "/architect "
+             (concat (format "refactor %s: " function-name) instruction))
+        (message "Code change request sent to Aider")))))))
 
 (defun aider--is-comment-line (line)
   "Check if LINE is a comment line based on current buffer's comment syntax.
@@ -302,8 +302,8 @@ This command requires the `flycheck` package to be installed and available."
                    (edited-prompt (aider-read-string "Edit prompt for Aider: " prompt)))
               (when (and edited-prompt (not (string-blank-p edited-prompt)))
                 (aider-add-current-file)
-                (aider--send-command (concat "/architect " edited-prompt) t)
-                (message "Sent request to Aider to fix %d Flycheck error(s) in %s." (length errors-in-scope) scope-description)))))))))
+                (when (aider--send-command (concat "/architect " edited-prompt) t)
+                  (message "Sent request to Aider to fix %d Flycheck error(s) in %s." (length errors-in-scope) scope-description)))))))))
 
 (provide 'aider-code-change)
 

--- a/aider-code-change.el
+++ b/aider-code-change.el
@@ -79,6 +79,7 @@ Otherwise, refactor the function under cursor."
                            '("Implement the function given description and hint in comment, make it be able to pass all unit-tests if there is"
                              "Simplify this code, reduce complexity and improve readability while preserving functionality"
                              "Fix potential bugs or issues in this code"
+                             "Given your code review feedback, make corresponding change" ;; code review using /ask firstly
                              "Make this code more maintainable and easier to test"
                              "Generate Docstring/Comment for This"
                              "Improve error handling and edge cases"

--- a/aider-core.el
+++ b/aider-core.el
@@ -327,7 +327,8 @@ Uses comint's built-in highlighting for input text."
 after performing necessary checks.
 COMMAND should be a string representing the command to send.
 Optional SWITCH-TO-BUFFER, when non-nil, switches to the aider buffer.
-Optional LOG, when non-nil, logs the command to the message area."
+Optional LOG, when non-nil, logs the command to the message area.
+Returns t if command was sent successfully, nil otherwise."
   ;; Check if the corresponding aider buffer exists
   (if-let ((aider-buffer (get-buffer (aider-buffer-name))))
       (let* ((command (replace-regexp-in-string "\\`[\n\r]+" "" command))   ;; Remove leading newlines
@@ -344,9 +345,14 @@ Optional LOG, when non-nil, logs the command to the message area."
                 (message "Sent command to aider buffer: %s" (string-trim command)))
               (when switch-to-buffer
                 (aider-switch-to-buffer))
-              (sleep-for 0.2))
-          (message "No active process found in buffer %s." (aider-buffer-name))))
-    (message "Buffer %s does not exist. Please start 'aider' first." (aider-buffer-name))))
+              (sleep-for 0.2)
+              t) ; Return t for success
+          (progn
+            (message "No active process found in buffer %s." (aider-buffer-name))
+            nil))) ; Return nil for failure
+    (progn
+      (message "Buffer %s does not exist. Please start 'aider' first." (aider-buffer-name))
+      nil))) ; Return nil for failure
 
 ;;;###autoload
 (defun aider-switch-to-buffer ()

--- a/aider-core.el
+++ b/aider-core.el
@@ -334,7 +334,7 @@ Optional SWITCH-TO-BUFFER, when non-nil, switches to the aider buffer.
 Optional LOG, when non-nil, logs the command to the message area.
 Returns t if command was sent successfully, nil otherwise."
   ;; Check if the corresponding aider buffer exists
-  (when-let ((aider-buffer (aider--validate-aider-buffer)))
+  (if-let ((aider-buffer (aider--validate-aider-buffer)))
     (let* ((command (replace-regexp-in-string "\\`[\n\r]+" "" command))   ;; Remove leading newlines
            (command (replace-regexp-in-string "[\n\r]+\\'" "" command)) ;; Remove trailing newlines
            (command (aider--process-message-if-multi-line command))

--- a/aider-discussion.el
+++ b/aider-discussion.el
@@ -51,8 +51,8 @@ With a prefix argument PREFIX, calls `aider-general-question` instead."
            (question-context (if region-text
                                  (format "%s: %s" question region-text)
                                question)))
-      (aider-current-file-command-and-switch "/ask " question-context)
-      (message "Question about code sent to Aider"))))
+      (when (aider-current-file-command-and-switch "/ask " question-context)
+        (message "Question about code sent to Aider")))))
 
 ;;;###autoload
 (defun aider-general-question ()

--- a/aider-file.el
+++ b/aider-file.el
@@ -149,7 +149,8 @@ Uses relative paths if files are in a git repository."
                (formatted-files (mapcar #'aider--format-file-path relative-files))
                ;; Construct the command string
                (command (concat command-prefix " " (mapconcat #'identity formatted-files " "))))
-          (aider--send-command command t))
+          (when (aider--send-command command t)
+            (message "Successfully added %d file(s) to Aider" (length absolute-files))))
       (message "No files marked in Dired."))))
 
 ;;;###autoload
@@ -188,12 +189,13 @@ Otherwise, add the current file as read-only."
     (aider-current-file-read-only)))
 
 (defun aider-current-file-command-and-switch (prefix command)
-  "Send COMMAND to the Aider buffer prefixed with PREFIX."
+  "Send COMMAND to the Aider buffer prefixed with PREFIX.
+Returns t if command was sent successfully, nil otherwise."
   (aider-add-current-file)
-  (aider--send-command (concat prefix command) t)
-  ;; (when (string-prefix-p "/architect" prefix)
-  ;;   (message "Note: Aider v0.77.0 automatically accept changes for /architect command. If you want to review the code change before accepting it like before for many commands in aider.el, you can disable that flag with \"--no-auto-accept-architect\" in aider-args or .aider.conf.yml."))
-  )
+  (let ((result (aider--send-command (concat prefix command) t)))
+    ;; (when (string-prefix-p "/architect" prefix)
+    ;;   (message "Note: Aider v0.77.0 automatically accept changes for /architect command. If you want to review the code change before accepting it like before for many commands in aider.el, you can disable that flag with \"--no-auto-accept-architect\" in aider-args or .aider.conf.yml."))
+    result))
 
 (defun aider--get-files-in-directory (directory suffixes)
   "Retrieve list of files in DIRECTORY matching SUFFIXES. SUFFIXES is a list of strings without dot."
@@ -243,14 +245,14 @@ With a prefix argument (C-u), files are added read-only (/read-only)."
          (formatted    (if rel-paths (mapcar #'aider--format-file-path rel-paths) nil)))
     (if filtered-files
         (progn
-          (aider--send-command (concat cmd-prefix " " (mapconcat #'identity formatted " ")) t)
-         (message (if read-only
-                      "Added %d files as read-only from %s%s"
-                    "Added %d files from %s%s")
-                  (length filtered-files) directory
-                  (if (and content-regex (not (string-empty-p content-regex)))
-                      (format " (matching content regex '%s')" content-regex)
-                    "")))
+          (when (aider--send-command (concat cmd-prefix " " (mapconcat #'identity formatted " ")) t)
+            (message (if read-only
+                         "Added %d files as read-only from %s%s"
+                       "Added %d files from %s%s")
+                     (length filtered-files) directory
+                     (if (and content-regex (not (string-empty-p content-regex)))
+                         (format " (matching content regex '%s')" content-regex)
+                       ""))))
       (message (format "No files found in %s with suffixes %s%s"
                        directory
                        suffix-input

--- a/aider-git.el
+++ b/aider-git.el
@@ -327,7 +327,7 @@ save it to 'PROJECT_ROOT/git.log', open this file, and then analyze its content.
                            repo-name context analysis-instructions)))
       (aider-add-current-file) ;; git.log
       (when (aider--send-command (concat "/ask " prompt) t)
-        (message "AI analysis of repository log initiated. Press (S) to skip questions if prompted by Aider."))))
+        (message "AI analysis of repository log initiated. Press (S) to skip questions if prompted by Aider.")))))
 
 ;;;###autoload
 (defun aider-magit-blame-or-log-analyze (&optional arg)

--- a/aider-git.el
+++ b/aider-git.el
@@ -279,8 +279,8 @@ code evolution and the reasoning behind changes."
          (prompt (format "Analyze the Git commit history for this code:\n\n%s%sCommit history information:\n```\n%s\n```\n\n%s"
                          context code-sample blame-output analysis-instructions)))
     (aider-add-current-file)
-    (aider--send-command (concat "/ask " prompt) t)
-    (message "Press (S) to skip questions when it pop up")))
+    (when (aider--send-command (concat "/ask " prompt) t)
+      (message "Press (S) to skip questions when it pop up"))))
 
 ;;;###autoload
 (defun aider-magit-log-analyze ()
@@ -326,8 +326,8 @@ save it to 'PROJECT_ROOT/git.log', open this file, and then analyze its content.
            (prompt (format "Analyze the Git commit history for the entire repository '%s'.\n\n%sThe detailed Git log content is in the 'git.log' file (which has been added to the chat).\nPlease use its content for your analysis, following these instructions:\n%s"
                            repo-name context analysis-instructions)))
       (aider-add-current-file) ;; git.log
-      (aider--send-command (concat "/ask " prompt) t)
-      (message "AI analysis of repository log initiated. Press (S) to skip questions if prompted by Aider."))))
+      (when (aider--send-command (concat "/ask " prompt) t)
+        (message "AI analysis of repository log initiated. Press (S) to skip questions if prompted by Aider."))))
 
 ;;;###autoload
 (defun aider-magit-blame-or-log-analyze (&optional arg)

--- a/aider-git.el
+++ b/aider-git.el
@@ -9,8 +9,10 @@
 
 ;;; Code:
 
-(require 'aider-core)
 (require 'magit)
+
+(require 'aider-core)
+(require 'aider-file)
 
 ;;;###autoload
 (defun aider-pull-or-review-diff-file ()

--- a/aider-software-planning.el
+++ b/aider-software-planning.el
@@ -100,8 +100,8 @@ a structured planning discussion with Aider using the
             (let ((initial-message (format "/ask %s\n\nMy goal is: %s"
                                            aider-software-planning--sequential-thinking-prompt
                                            goal)))
-              (aider--send-command initial-message t)
-              (message "Software planning session started for goal: %s, after that, use /ask to follow up with aider step by step" goal))
+              (when (aider--send-command initial-message t)
+                (message "Software planning session started for goal: %s, after that, use /ask to follow up with aider step by step" goal)))
           (message "Aider buffer could not be created or found. Planning session not started."))))))
 
 (provide 'aider-software-planning)

--- a/aider-software-planning.el
+++ b/aider-software-planning.el
@@ -94,8 +94,6 @@ a structured planning discussion with Aider using the
         (message "Goal cannot be empty. Planning session not started.")
       (progn
         ;; Ensure Aider is running
-        (unless (aider--validate-aider-buffer)
-          (call-interactively #'aider-run-aider))
         (when (aider--validate-aider-buffer)
           (let ((initial-message (format "/ask %s\n\nMy goal is: %s"
                                          aider-software-planning--sequential-thinking-prompt

--- a/aider.el
+++ b/aider.el
@@ -210,7 +210,7 @@ specific patterns (e.g., OpenAI's o4, o3, o1 series)."
            (effort (completing-read "Select reasoning effort: " efforts nil t nil nil "medium")))
       (when effort
         (when (aider--send-command (format "/reasoning-effort %s" effort) t)
-          (message "Reasoning effort set to %s for model %s" effort model)))))
+          (message "Reasoning effort set to %s for model %s" effort model))))))
 
 ;;;###autoload
 (defun aider-change-model (leaderboards)
@@ -227,7 +227,7 @@ Allows selecting between /model, /editor-model, and /weak-model commands."
         (when (aider--send-command (format "%s %s" command model) t)
           (message "%s changed to %s, customize aider-popular-models for the model candidates"
                    (substring command 1) model)
-          (aider--maybe-prompt-and-set-reasoning-effort command model)))))
+          (aider--maybe-prompt-and-set-reasoning-effort command model))))))
 
 (provide 'aider)
 

--- a/aider.el
+++ b/aider.el
@@ -208,8 +208,8 @@ specific patterns (e.g., OpenAI's o4, o3, o1 series)."
     (let* ((efforts '("low" "medium" "high"))
            (effort (completing-read "Select reasoning effort: " efforts nil t nil nil "medium")))
       (when effort
-        (aider--send-command (format "/reasoning-effort %s" effort) t)
-        (message "Reasoning effort set to %s for model %s" effort model)))))
+        (when (aider--send-command (format "/reasoning-effort %s" effort) t)
+          (message "Reasoning effort set to %s for model %s" effort model)))))
 
 ;;;###autoload
 (defun aider-change-model (leaderboards)
@@ -223,10 +223,10 @@ Allows selecting between /model, /editor-model, and /weak-model commands."
            (command (completing-read "Select model command: " commands nil t))
            (model (completing-read "Select AI model: " aider-popular-models nil t nil nil (car aider-popular-models))))
       (when model
-        (aider--send-command (format "%s %s" command model) t)
-        (message "%s changed to %s, customize aider-popular-models for the model candidates"
-                 (substring command 1) model)
-        (aider--maybe-prompt-and-set-reasoning-effort command model)))))
+        (when (aider--send-command (format "%s %s" command model) t)
+          (message "%s changed to %s, customize aider-popular-models for the model candidates"
+                   (substring command 1) model)
+          (aider--maybe-prompt-and-set-reasoning-effort command model)))))
 
 (provide 'aider)
 

--- a/appendix.org
+++ b/appendix.org
@@ -1,4 +1,37 @@
 
+* Recent New Features
+
+** Software Planning Discussion
+
+- aider-software-planning :: use Software Planning using code from the mcp server (~C-c a P~)
+  - Software Planning is a mcp server designed to facilitate software development planning through an interactive, structured approach. It helps break down complex software projects into manageable tasks.
+
+** Let aider to fix the errors reported by flycheck
+
+- aider-flycheck-fix-errors-in-scope :: Flycheck output will be sent to aider as context to fix the error. It support:
+  - current function
+  - selected region
+  - whole file (C-u)
+
+** File / repo change history analysis with magit-blame and magit-log integration 
+
+- aider-magit-blame-analyze :: combines magit-blame with AI analysis to help understand code history and reasoning behind changes for a file or selected region (~C-c a e~).
+- aider-aider-magit-log-analyze :: integrates magit-log with AI analysis to provide insights into commit history and evolution of the repository (~C-u C-c a e~).
+
+** Bootstrap New File 
+
+- aider-bootstrap :: Bootstrap common code / doc structures (Code, Config, Doc, Slides, etc, ~C-c a B~)
+
+** Aider-comint-session be able to scroll up / search the prompt across sessions
+
+- By parsing .aider.input.history
+- Use ctrl + up / down key to scroll, alt + r to search
+
+** Multiple chats for the same repository
+
+- To turn on this feature, ~(setq aider-use-branch-specific-buffers t)~
+- *If we want to switch to work on a different feature, we switch git branch, and it will map to a corresponding aider session.* The aider session name pattern would be ~aider:<path-to-git-repo>:branch-name~ 
+
 * Other ways to install aider.el
 
 ** With [[https://www.gnu.org/software/emacs/manual/html_node/emacs/Fetching-Package-Sources.html#:~:text=One%20way%20to%20do%20this,just%20like%20any%20other%20package.][package-vc-install]] (Emacs 30+ built-in)
@@ -59,39 +92,6 @@ The aider prefix is ~A~.
   - ~M-x yas-expand~ to expand the snippet under cursor.
 
 - Welcome to add more snippets / improve existing snippets in the [[./snippets/aider-prompt-mode][snippets folder]]!
-
-* Recent New Features
-
-** Software Planning Discussion
-
-- aider-software-planning :: use Software Planning using code from the mcp server (~C-c a P~)
-  - Software Planning is a mcp server designed to facilitate software development planning through an interactive, structured approach. It helps break down complex software projects into manageable tasks.
-
-** Let aider to fix the errors reported by flycheck
-
-- aider-flycheck-fix-errors-in-scope :: Flycheck output will be sent to aider as context to fix the error. It support:
-  - current function
-  - selected region
-  - whole file (C-u)
-
-** File / repo change history analysis with magit-blame and magit-log integration 
-
-- aider-magit-blame-analyze :: combines magit-blame with AI analysis to help understand code history and reasoning behind changes for a file or selected region (~C-c a e~).
-- aider-aider-magit-log-analyze :: integrates magit-log with AI analysis to provide insights into commit history and evolution of the repository (~C-u C-c a e~).
-
-** Bootstrap New File 
-
-- aider-bootstrap :: Bootstrap common code / doc structures (Code, Config, Doc, Slides, etc, ~C-c a B~)
-
-** Aider-comint-session be able to scroll up / search the prompt across sessions
-
-- By parsing .aider.input.history
-- Use ctrl + up / down key to scroll, alt + r to search
-
-** Multiple chats for the same repository
-
-- To turn on this feature, ~(setq aider-use-branch-specific-buffers t)~
-- *If we want to switch to work on a different feature, we switch git branch, and it will map to a corresponding aider session.* The aider session name pattern would be ~aider:<path-to-git-repo>:branch-name~ 
 
 * Be careful about AI generated code
 

--- a/appendix.org
+++ b/appendix.org
@@ -93,6 +93,13 @@ The aider prefix is ~A~.
 
 - Welcome to add more snippets / improve existing snippets in the [[./snippets/aider-prompt-mode][snippets folder]]!
 
+* Cons of aider.el
+
+- The current implementation is using comint to host aider session, a classic CLI interactive solution used in emacs, However, comint-mode initially _doesn't have the advance features such as codeblock color rendering and file tracking_ from aider.
+  - *color rendering from markdown-mode.el is applied in aider comint session buffer it and largely improved this*.
+  - Without file tracking, aider.el cannot do [[https://aider.chat/docs/usage/watch.html#ai-comments][AI comments]]. *The work around we provided is ~aider-implement-todo~*, It use architect command to ask aider to implement comment under cursor by default. I constantly use this feature and feel it is OK.
+  - [[https://github.com/akermu/emacs-libvterm][vterm based interactive session]] can make the aider session close to the user experience of using aider in terminal. Considering that comint based solution is battle tested for many years and it is very stable, and long term maintainability of the project, aider.el only use comint session based solution. 
+
 * Be careful about AI generated code
 
 - Thanks to LLM. It is so easy to generate bunch of code with AI. But generating code doesn't complete the work. 

--- a/appendix.org
+++ b/appendix.org
@@ -1,0 +1,144 @@
+
+* Other ways to install aider.el
+
+** With [[https://www.gnu.org/software/emacs/manual/html_node/emacs/Fetching-Package-Sources.html#:~:text=One%20way%20to%20do%20this,just%20like%20any%20other%20package.][package-vc-install]] (Emacs 30+ built-in)
+- Install aider.el by running the following code within Emacs
+  - You'll need to manually install the required packages, such as [[https://github.com/magit/transient][Transient]], [[https://github.com/magit/magit][Magit]], and helm.
+
+#+BEGIN_SRC emacs-lisp
+(package-vc-install '(aider :url "https://github.com/tninja/aider.el"))
+#+END_SRC
+
+The config part is as same as above one
+
+** With [[https://github.com/radian-software/straight.el?tab=readme-ov-file][Straight]]
+If you have Straight installed
+#+BEGIN_SRC emacs-lisp
+  (use-package aider
+    :straight (:host github :repo "tninja/aider.el")
+    :config
+    ;; rest of configs
+    )
+#+END_SRC
+
+** Doom Installation and Configuration
+
+- Add the following code to your doom/packages.el
+
+#+BEGIN_SRC emacs-lisp
+(package! aider :recipe (:host github :repo "tninja/aider.el" ))
+#+END_SRC
+
+- Adjust and add the following code to your doom/config.el
+
+#+BEGIN_SRC emacs-lisp
+(use-package aider
+  :config
+  (setq aider-args '("--model" "sonnet"))
+  (require 'aider-doom))
+#+END_SRC
+
+The aider prefix is ~A~.
+
+- Start and open the aider buffer: =[SPC] A p a=
+- Add the current file with =[SPC] A f f=
+- Reset the aider session with =[SPC] A p s=
+[[file:./doom_menus.png]]
+
+- *However, transient menu is more recommended than doom menu*, cause I constantly use that one so it is better maintained.
+  - Anyone want to contribute to doom menu, feel free to help on it. Thanks.
+ 
+* [[./snippets/aider-prompt-mode][Prompt Snippets]]
+- Prompts for aider might share similar structure. Yasnippet can be used to help reusing these prompts.
+
+- Aider prompt file now support yasnippet. Current snippets came from [[https://www.reddit.com/r/ClaudeAI/comments/1f0ya1t/i_used_claude_to_write_an_sop_for_using_claude/?utm_source=share&utm_medium=web3x&utm_name=web3xcss&utm_term=1&utm_content=share_button][this reddit post]], [[https://www.reddit.com/r/ChatGPTCoding/comments/1f51y8s/a_collection_of_prompts_for_generating_high/][another reddit post]], and a [[https://github.com/PickleBoxer/dev-chatgpt-prompts][git repo]].
+
+- You can use
+  - ~M-x yas-describe-tables~ to see the available snippets
+  - ~M-x yas-insert-snippet~ to insert a snippet.
+  - ~M-x yas-expand~ to expand the snippet under cursor.
+
+- Welcome to add more snippets / improve existing snippets in the [[./snippets/aider-prompt-mode][snippets folder]]!
+
+* Recent New Features
+
+** Software Planning Discussion
+
+- aider-software-planning :: use Software Planning using code from the mcp server (~C-c a P~)
+  - Software Planning is a mcp server designed to facilitate software development planning through an interactive, structured approach. It helps break down complex software projects into manageable tasks.
+
+** Let aider to fix the errors reported by flycheck
+
+- aider-flycheck-fix-errors-in-scope :: Flycheck output will be sent to aider as context to fix the error. It support:
+  - current function
+  - selected region
+  - whole file (C-u)
+
+** File / repo change history analysis with magit-blame and magit-log integration 
+
+- aider-magit-blame-analyze :: combines magit-blame with AI analysis to help understand code history and reasoning behind changes for a file or selected region (~C-c a e~).
+- aider-aider-magit-log-analyze :: integrates magit-log with AI analysis to provide insights into commit history and evolution of the repository (~C-u C-c a e~).
+
+** Bootstrap New File 
+
+- aider-bootstrap :: Bootstrap common code / doc structures (Code, Config, Doc, Slides, etc, ~C-c a B~)
+
+** Aider-comint-session be able to scroll up / search the prompt across sessions
+
+- By parsing .aider.input.history
+- Use ctrl + up / down key to scroll, alt + r to search
+
+** Multiple chats for the same repository
+
+- To turn on this feature, ~(setq aider-use-branch-specific-buffers t)~
+- *If we want to switch to work on a different feature, we switch git branch, and it will map to a corresponding aider session.* The aider session name pattern would be ~aider:<path-to-git-repo>:branch-name~ 
+
+* Be careful about AI generated code
+
+- Thanks to LLM. It is so easy to generate bunch of code with AI. But generating code doesn't complete the work. 
+  - There might be potential bug hidden inside. It need to be verified that the feature work as expected, and code change didn't break existing features.
+  - Developer might be lack of understanding of AI generated code. If there is too many code developer don't quite understand, the project could be out of control, like this:
+
+#+BEGIN_HTML
+  <img src="https://i.redd.it/puzjerkgcfqe1.jpeg" width="300" />
+#+END_HTML
+
+- *Unit-test can be useful on both of the above concern*. And aider can help writing unit tests.
+  - The AI generated test need to be manually checked / fixed. But generally test code is easier to understand.
+  - Running the unit-tests can help verifying the correctness / identifying the bug of code. It also help developer better understanding how the AI generated code work, and it can give developer more confidence on the new code.
+
+** A weak [[https://en.wikipedia.org/wiki/Test-driven_development][TDD]] style AI programming workflow
+
+1. *Implement or modify code*
+   - For existing code: Use ~aider-function-or-region-refactor~ with cursor in function or on selected region
+   - For new code: Use ~aider-implement-todo~ on TODO comments
+   
+   *Example of adding new code*:
+   
+   With cursor on this comment:
+   #+BEGIN_SRC python :eval never
+   # TODO: Implement a function that checks if a number is prime
+   #+END_SRC
+   
+   Running ~aider-implement-todo~ might generate:
+   #+BEGIN_SRC python :eval never
+   def is_prime(n):
+       if n <= 1:
+           return False
+       for i in range(2, int(n ** 0.5) + 1):
+           if n % i == 0:
+               return False
+       return True
+   #+END_SRC
+   
+   If suggestions aren't satisfactory, use ~Ask Question~ for refinements and ~Go Ahead~ to confirm changes.
+
+2. *Generate tests*: Validate your implementation with ~aider-write-unit-test~. Do run the test to validate code behavior.
+   - ~aider-write-unit-test~ can be used to write unit-test before the code is implemented, just call the function in the unit-test class. I tried it with leetcode problems and it works pretty well.
+
+3. *Refine code and tests*: Further refactor as needed using additional prompts or manual adjustments. ~aider-refactor-book-method~ have couple of refactoring techniques from [[https://www.amazon.com/Refactoring-Improving-Existing-Addison-Wesley-Signature/dp/0134757599/ref=asc_df_0134757599?mcid=2eb8b1a5039a3b7c889ee081fc2132e0&hvocijid=16400341203663661896-0134757599-&hvexpln=73&tag=hyprod-20&linkCode=df0&hvadid=721245378154&hvpos=&hvnetw=g&hvrand=16400341203663661896&hvpone=&hvptwo=&hvqmt=&hvdev=c&hvdvcmdl=&hvlocint=&hvlocphy=9032161&hvtargid=pla-2281435180458&psc=1][Martin Flower's Refactoring book]]
+
+4. Goto 1
+
+- Alternatively, if you prefer strong TDD practice, you might want to try ~aider-tdd-cycle~, it will follow strict red-green-refactor cycle.
+

--- a/etc/aider-etc.el
+++ b/etc/aider-etc.el
@@ -98,7 +98,7 @@ If there are more than 40 files, refuse to add and show warning message."
               (command nil))
           (when formatted-files
             (setq command (concat "/add " (mapconcat #'identity formatted-files " ")))
-            (aider--send-command command t)
-            (message "Added %d files with suffix .%s"
-                     (length files) current-suffix))
+            (when (aider--send-command command t)
+              (message "Added %d files with suffix .%s"
+                       (length files) current-suffix)))
           )))))


### PR DESCRIPTION
For example, do not show additional message. If aider--send-command failed, that function will show message to user and shouldn't be overwrite.