### PR TITLE
Feat: Tiny improvement to aider-add-module function

### DIFF
--- a/aider-file.el
+++ b/aider-file.el
@@ -235,7 +235,7 @@ With a prefix argument (C-u), files are added read-only (/read-only)."
          (read-directory-name "Module directory: " nil nil t)
          (read-string "File suffixes (comma-separated): "
                       (let ((ext (when (buffer-file-name)
-                                   (file-name-extension (buffer-file-name))))
+                                   (file-name-extension (buffer-file-name)))))
                         (if ext ext "py,java,scala,el,sql")))
          (read-string "Content regex (empty for none): "
                       (or (thing-at-point 'symbol) ""))))

--- a/aider-file.el
+++ b/aider-file.el
@@ -234,8 +234,11 @@ With a prefix argument (C-u), files are added read-only (/read-only)."
    (list current-prefix-arg
          (read-directory-name "Module directory: " nil nil t)
          (read-string "File suffixes (comma-separated): "
-                      "py,java,scala,el,sql")
-         (read-string "Content regex (empty for none): " nil)))
+                      (let ((ext (when (buffer-file-name)
+                                   (file-name-extension (buffer-file-name))))
+                        (if ext ext "py,java,scala,el,sql")))
+         (read-string "Content regex (empty for none): "
+                      (or (thing-at-point 'symbol) ""))))
   (let* ((cmd-prefix   (if read-only "/read-only" "/add"))
          (suffixes     (split-string suffix-input "\\s-*,\\s-*" t))
          (files-by-suffix (aider--get-files-in-directory directory suffixes))

--- a/aider.el
+++ b/aider.el
@@ -64,8 +64,7 @@
 (defcustom aider-popular-models '("sonnet"  ;; really good in practical
                                   "gemini"  ;; SOTA
                                   "o4-mini" ;; good for difficult task
-                                  ;; "gemini-exp"  ;; google stop this free service :(
-                                  "deepseek"  ;; low price, pretty good performance
+                                  "deepseek/deepseek-reasoner" ;; DeepSeek R1 (0528), low price, pretty good performance
                                   )
   "List of available AI models for selection.
 Each model should be in the format expected by the aider command line interface.


### PR DESCRIPTION
1. suffix-input default value use suffix of current buffer file
2. content-regex default value use symbol under point

also update deepseek model to DeepSeek R1 (0528). It looks good after tried.