### PR TITLE
Feat: Add aider-expand-context-current-file

### DIFF
--- a/HISTORY.org
+++ b/HISTORY.org
@@ -3,7 +3,7 @@
 
 ** Main branch change
 
-- file completion for /drop only list added files, addressing https://github.com/tninja/aider.el/issues/179
+- File completion for /drop only list added files, addressing https://github.com/tninja/aider.el/issues/179
 - Add whole git repo evolution analysis: aider-magit-log-analyze
   - Update menu item to aider-magit-blame-or-log-analyze
 - Add aider-magit-setup-transients function to register Aider commands with Magit transients
@@ -16,6 +16,7 @@
   - Addressing 1. #159; 2. MatthewZMD/aidermacs#141
 - aider-add-module function have better default value for user input (suffix-input, content-regex)
 - Update popular model: deepseek to DeepSeek R1 (0528)
+- Introduce aider-expand-context-current-file. It suggest a semi-automatic way to add relevant file. It add current file and its dependencies/dependents to aider session. Given current buffer source code file.
 
 ** v0.11.1
 

--- a/HISTORY.org
+++ b/HISTORY.org
@@ -1,7 +1,7 @@
 
 * Release history
 
-** Main branch change
+** v0.12.0
 
 - File completion for /drop only list added files, addressing https://github.com/tninja/aider.el/issues/179
 - Add whole git repo evolution analysis: aider-magit-log-analyze

--- a/aider-discussion.el
+++ b/aider-discussion.el
@@ -9,9 +9,10 @@
 
 ;;; Code:
 
+(require 'which-func)
+
 (require 'aider-core)
 (require 'aider-file)
-(require 'which-func)
 
 ;; New function to get command from user and send it prefixed with "/ask "
 ;;;###autoload

--- a/aider-file.el
+++ b/aider-file.el
@@ -266,7 +266,8 @@ With a prefix argument (C-u), files are added read-only (/read-only)."
 (defun aider-expand-context-current-file ()
   "Add current file and its dependencies/dependents to aider session.
 Given current buffer source code file, figure out the source code files that depend on it,
-and the source code files it depends on."
+and the source code files it depends on.
+User can choose between /add or /read-only command."
   (interactive)
   (when (aider--validate-buffer-file)
     (let* ((current-file (buffer-file-name))
@@ -276,7 +277,8 @@ and the source code files it depends on."
            (dependents (aider--find-file-dependents current-file search-root))
            (all-files (delete-dups (append (list current-file) dependencies dependents))))
       (if (> (length all-files) 1)
-          (progn
+          (let* ((commands '("/add" "/read-only"))
+                 (command (completing-read "Select command for files: " commands nil t nil nil "/add")))
             (message "Dependencies: %s; Dependents: %s"
                      (mapconcat #'identity
                                 (mapcar #'file-name-nondirectory dependencies)
@@ -287,7 +289,7 @@ and the source code files it depends on."
             (let* ((relative-files (mapcar #'aider--get-file-path all-files))
                    (formatted-files (mapcar #'aider--format-file-path relative-files)))
               (dolist (file formatted-files)
-                (aider--send-command (concat "/add " file) nil))
+                (aider--send-command (concat command " " file) nil))
               (aider-switch-to-buffer)))
         (message "No additional dependencies or dependents found for current file")))))
 

--- a/aider-file.el
+++ b/aider-file.el
@@ -283,11 +283,8 @@ and the source code files it depends on."
                                 ", "))
             (let* ((relative-files (mapcar #'aider--get-file-path all-files))
                    (formatted (mapcar #'aider--format-file-path relative-files))
-                   (to-add (completing-read-multiple
-                            "Select files to add (comma separated): "
-                            formatted nil t formatted)))
-              (dolist (file to-add)
-                (aider--send-command (concat "/add " file) t))))
+                   (command (concat "/add " (mapconcat #'identity formatted " "))))
+              (aider--send-command command t)))
         (message "No additional dependencies or dependents found for current file")))))
 
 (defun aider--find-file-dependencies (file-path search-root)

--- a/aider-file.el
+++ b/aider-file.el
@@ -260,7 +260,7 @@ With a prefix argument (C-u), files are added read-only (/read-only)."
                          ""))))))
 
 ;;;###autoload
-(defun aider-expand-context ()
+(defun aider-expand-context-current-file ()
   "Add current file and its dependencies/dependents to aider session.
 Given current buffer source code file, figure out the source code files that depend on it,
 and the source code files it depends on."
@@ -284,7 +284,8 @@ and the source code files it depends on."
             (let* ((relative-files (mapcar #'aider--get-file-path all-files))
                    (formatted-files (mapcar #'aider--format-file-path relative-files)))
               (dolist (file formatted-files)
-                (aider--send-command (concat "/add " file) t))))
+                (aider--send-command (concat "/add " file) nil))
+              (aider-switch-to-buffer)))
         (message "No additional dependencies or dependents found for current file")))))
 
 (defun aider--find-file-dependencies (file-path search-root)

--- a/aider-file.el
+++ b/aider-file.el
@@ -344,6 +344,11 @@ Returns a list of absolute file paths."
                   (push (expand-file-name file) candidate-files)))
               (forward-line 1))))
         (kill-buffer temp-buffer)))
+    ;; Filter out files starting with flycheck_ prefix
+    (setq candidate-files (seq-filter (lambda (file)
+                                        (not (string-prefix-p "flycheck_" 
+                                                              (file-name-nondirectory file))))
+                                      candidate-files))
     candidate-files))
 
 (defun aider--find-file-dependents (file-path search-root)

--- a/aider-file.el
+++ b/aider-file.el
@@ -283,8 +283,11 @@ and the source code files it depends on."
                                 ", "))
             (let* ((relative-files (mapcar #'aider--get-file-path all-files))
                    (formatted (mapcar #'aider--format-file-path relative-files))
-                   (command (concat "/add " (mapconcat #'identity formatted " "))))
-              (aider--send-command command t)))
+                   (to-add (completing-read-multiple
+                            "Select files to add (comma separated): "
+                            formatted nil t formatted)))
+              (dolist (file to-add)
+                (aider--send-command (concat "/add " file) t))))
         (message "No additional dependencies or dependents found for current file")))))
 
 (defun aider--find-file-dependencies (file-path search-root)

--- a/aider-file.el
+++ b/aider-file.el
@@ -288,7 +288,7 @@ and the source code files it depends on."
                             "Select files to add: " formatted nil t formatted)))
               (dolist (file to-add)
                 (aider--send-command (concat "/add " file) t))))
-        (message "No additional dependencies or dependents found for current file"))))
+        (message "No additional dependencies or dependents found for current file")))))
 
 (defun aider--find-file-dependencies (file-path search-root)
   "Find files that FILE-PATH depends on by searching for filenames mentioned in the file.

--- a/aider-file.el
+++ b/aider-file.el
@@ -274,20 +274,17 @@ and the source code files it depends on."
            (all-files (delete-dups (append (list current-file) dependencies dependents))))
       (if (> (length all-files) 1)
           (progn
-            (message "Dependencies: %s"
+            (message "Dependencies: %s; Dependents: %s"
                      (mapconcat #'identity
                                 (mapcar #'file-name-nondirectory dependencies)
-                                ", "))
-            (message "Dependents: %s"
+                                ", ")
                      (mapconcat #'identity
                                 (mapcar #'file-name-nondirectory dependents)
                                 ", "))
             (let* ((relative-files (mapcar #'aider--get-file-path all-files))
                    (formatted (mapcar #'aider--format-file-path relative-files))
-                   (to-add (completing-read-multiple
-                            "Select files to add: " formatted nil t formatted)))
-              (dolist (file to-add)
-                (aider--send-command (concat "/add " file) t))))
+                   (command (concat "/add " (mapconcat #'identity formatted " "))))
+              (aider--send-command command t)))
         (message "No additional dependencies or dependents found for current file")))))
 
 (defun aider--find-file-dependencies (file-path search-root)

--- a/aider-file.el
+++ b/aider-file.el
@@ -372,7 +372,8 @@ Returns list of absolute file paths."
   (list (concat "*." file-ext)))
 
 (defun aider--find-files-by-patterns (search-root patterns)
-  "Find all files matching PATTERNS in SEARCH-ROOT."
+  "Find all files matching PATTERNS in SEARCH-ROOT.
+Ignores files with flycheck_ prefix."
   (let ((found-files '()))
     (dolist (pattern patterns)
       (let* ((cmd (list "find" search-root "-name" pattern "-type" "f"))
@@ -380,6 +381,11 @@ Returns list of absolute file paths."
                       (when (zerop (apply #'call-process (car cmd) nil t nil (cdr cmd)))
                         (split-string (buffer-string) "\n" t)))))
         (setq found-files (append found-files result))))
+    ;; Filter out files starting with flycheck_ prefix
+    (setq found-files (seq-filter (lambda (file)
+                                    (not (string-prefix-p "flycheck_" 
+                                                          (file-name-nondirectory file))))
+                                  found-files))
     (delete-dups (mapcar #'expand-file-name found-files))))
 
 (defun aider--file-mentions-basename (file-path basename)

--- a/aider-file.el
+++ b/aider-file.el
@@ -282,9 +282,9 @@ and the source code files it depends on."
                                 (mapcar #'file-name-nondirectory dependents)
                                 ", "))
             (let* ((relative-files (mapcar #'aider--get-file-path all-files))
-                   (formatted (mapcar #'aider--format-file-path relative-files))
-                   (command (concat "/add " (mapconcat #'identity formatted " "))))
-              (aider--send-command command t)))
+                   (formatted-files (mapcar #'aider--format-file-path relative-files)))
+              (dolist (file formatted-files)
+                (aider--send-command (concat "/add " file) t))))
         (message "No additional dependencies or dependents found for current file")))))
 
 (defun aider--find-file-dependencies (file-path search-root)

--- a/aider-file.el
+++ b/aider-file.el
@@ -346,8 +346,9 @@ Returns list of absolute file paths."
       (let ((regex (format "\\b%s\\b" (regexp-quote basename)))
             found)
         (while (and (not found) (re-search-forward regex nil t))
-          ;; skip match if inside a comment
-          (unless (nth 4 (syntax-ppss)) (setq found t)))
+          ;; Only count match if NOT inside a comment
+          (unless (nth 4 (syntax-ppss))
+            (setq found t)))
         found))))
 
 (provide 'aider-file)

--- a/aider.el
+++ b/aider.el
@@ -1,7 +1,7 @@
 ;;; aider.el --- AI assisted programming with Aider and LLM  -*- lexical-binding: t; -*-
 
 ;; Author: Kang Tu <tninja@gmail.com>
-;; Version: 0.11.1
+;; Version: 0.12.0
 ;; Package-Requires: ((emacs "26.1") (transient "0.9.0") (magit "2.1.0") (markdown-mode "2.5") (s "1.13.0"))
 ;; Keywords: ai gpt sonnet llm aider gemini-pro deepseek ai-assisted-coding
 ;; URL: https://github.com/tninja/aider.el

--- a/aider.el
+++ b/aider.el
@@ -98,7 +98,7 @@ Also based on aider LLM benchmark: https://aider.chat/docs/leaderboards/"
   ("p" "Input with Repo Prompt File"     aider-open-prompt-file)
   ("s" "Reset Aider (C-u: clear)"        aider-reset)
   ("o" "Select Model (C-u: benchmark)" aider-change-model)
-  ("x" "Exit Aider"                      aider-exit))
+  ("X" "Exit Aider"                      aider-exit))
 
 ;;; Transient menu items for the “File Operation” section.
 (transient-define-group aider--menu-file-operation
@@ -106,6 +106,7 @@ Also based on aider LLM benchmark: https://aider.chat/docs/leaderboards/"
   ("w" "Add All Files in Window"                  aider-add-files-in-current-window)
   ("M" "Add Module w/o grep (C-u: readonly)"      aider-add-module)
   ("O" "Drop File in Buffer / under Cursor"       aider-drop-current-file)
+  ("x" "Expand Context for Current File"          aider-expand-context-current-file)
   ("m" "Show Last Commit (C-u: magit-log)"        aider-magit-show-last-commit-or-log)
   ("u" "Undo Last Change"                         aider-undo-last-change)
   ("v" "Pull or Review Code Change"               aider-pull-or-review-diff-file)

--- a/aider.el
+++ b/aider.el
@@ -110,7 +110,8 @@ Also based on aider LLM benchmark: https://aider.chat/docs/leaderboards/"
   ("m" "Show Last Commit (C-u: magit-log)"        aider-magit-show-last-commit-or-log)
   ("u" "Undo Last Change"                         aider-undo-last-change)
   ("v" "Pull or Review Code Change"               aider-pull-or-review-diff-file)
-  ("e" "File Evolution Analysis (C-u: Repo)"      aider-magit-blame-or-log-analyze))
+  ("e" "File Evolution Analysis (C-u: Repo)"      aider-magit-blame-or-log-analyze)
+  ("r" "Reset Aider (C-u: clear)"                 aider-reset))
 
 ;;; Transient menu items for the “Code Change” section.
 (transient-define-group aider--menu-code-change

--- a/aider.el
+++ b/aider.el
@@ -97,7 +97,7 @@ Also based on aider LLM benchmark: https://aider.chat/docs/leaderboards/"
   ("z" "Switch to Aider Buffer"          aider-switch-to-buffer)
   ("p" "Input with Repo Prompt File"     aider-open-prompt-file)
   ("s" "Reset Aider (C-u: clear)"        aider-reset)
-  ("o" "Select Model (C-u: benchmark)" aider-change-model)
+  ("o" "Select Model (C-u: benchmark)"   aider-change-model)
   ("X" "Exit Aider"                      aider-exit))
 
 ;;; Transient menu items for the “File Operation” section.
@@ -110,8 +110,7 @@ Also based on aider LLM benchmark: https://aider.chat/docs/leaderboards/"
   ("m" "Show Last Commit (C-u: magit-log)"        aider-magit-show-last-commit-or-log)
   ("u" "Undo Last Change"                         aider-undo-last-change)
   ("v" "Pull or Review Code Change"               aider-pull-or-review-diff-file)
-  ("e" "File Evolution Analysis (C-u: Repo)"      aider-magit-blame-or-log-analyze)
-  ("r" "Reset Aider (C-u: clear)"                 aider-reset))
+  ("e" "File Evolution Analysis (C-u: Repo)"      aider-magit-blame-or-log-analyze))
 
 ;;; Transient menu items for the “Code Change” section.
 (transient-define-group aider--menu-code-change


### PR DESCRIPTION
Context size of LLM are increasing, and the price per token are dropping. Adding more relevant files as context is potentially useful for aider AI coding with low cost.

Currently aider need user to add relevant file through /add or /read-only manually. This PR suggest a semi-automatic way. It add current file and its dependencies/dependents to aider session. Given current buffer source code file, figure out the source code files that depend on it, and the source code files it depends on.