### PR TITLE
Feat: Improve dependencies / dependent file identification

### DIFF
--- a/aider-file.el
+++ b/aider-file.el
@@ -12,10 +12,10 @@
 (require 'dired)
 (require 'magit)
 (require 'ffap)
+(require 'cl-lib)
 
 (require 'aider-core)
 
-(require 'cl-lib)
 
 ;; Added helper function to get the relative or absolute path of the file
 (defun aider--get-file-path (file-path)


### PR DESCRIPTION
Improvments:

1. to skip matches in both comments and strings 
2. require that the basename appears in a context that suggests it is an import or a dependency
3. ask user if test file need to be included