### PR TITLE
Refactor: Move functions from aider-core.el to aider-util.el and aider-comint-markdown.el

### DIFF
--- a/aider-agile.el
+++ b/aider-agile.el
@@ -178,7 +178,9 @@ If TDD-MODE is non-nil, adds TDD constraints to the prompt."
          (context-info (cond
                         (region-active "Selected code region")
                         (current-function (format "Function '%s'" current-function))
-                        (t "All added files")))
+                        (t ;; use current buffer file name when no region/function
+                         (let ((fname (plist-get context :file-name)))
+                           (format "File '%s'" (or fname "All added files"))))))
          (code-snippet (if region-active
                            (format "\n```\n%s\n```" region-text)
                          ""))

--- a/aider-comint-markdown.el
+++ b/aider-comint-markdown.el
@@ -1,5 +1,13 @@
 ;;; aider-comint-markdown.el --- Markdown highlighting and advice for Aider -*- lexical-binding: t; -*-
+
+;; Author: Kang Tu <tninja@gmail.com>
+
+;; SPDX-License-Identifier: Apache-2.0
+
+;;; Commentary:
 ;; Provide safe markdown functions and highlighting setup for aider-comint-mode
+
+;;; Code:
 
 (require 'markdown-mode)
 (require 'seq)

--- a/aider-comint-markdown.el
+++ b/aider-comint-markdown.el
@@ -1,0 +1,70 @@
+;;; aider-comint-markdown.el --- Markdown highlighting and advice for Aider -*- lexical-binding: t; -*-
+;; Provide safe markdown functions and highlighting setup for aider-comint-mode
+
+(require 'markdown-mode)
+(require 'seq)
+
+(defun aider--safe-maybe-funcall-regexp (origfn object &optional arg)
+  "Call ORIGFN (`markdown-maybe-funcall-regexp') safely in aider buffers only."
+  (if (eq major-mode 'aider-comint-mode)
+      (condition-case nil
+          (cond ((functionp object)
+                 (condition-case nil
+                     (if arg (funcall object arg) (funcall object))
+                   (error "")))
+                ((stringp object) object)
+                ((null object) "")
+                (t ""))
+        (error ""))
+    (funcall origfn object arg)))
+
+(defun aider--safe-get-start-fence-regexp (origfn &rest args)
+  "Safely call `markdown-get-start-fence-regexp' in aider buffers only."
+  (if (eq major-mode 'aider-comint-mode)
+      (condition-case nil
+          (let ((res (apply origfn args)))
+            (if (and res (stringp res) (not (string-empty-p res))) res "\\`never-match\\`"))
+        (error "\\`never-match\\`"))
+    (apply origfn args)))
+
+(defun aider--safe-syntax-propertize-fenced-block-constructs (origfn start end)
+  "Safely call `markdown-syntax-propertize-fenced-block-constructs' in aider buffers only."
+  (if (eq major-mode 'aider-comint-mode)
+      (condition-case nil
+          (funcall origfn start end)
+        (error nil))
+    (funcall origfn start end)))
+
+(advice-add 'markdown-maybe-funcall-regexp :around #'aider--safe-maybe-funcall-regexp)
+(advice-add 'markdown-get-start-fence-regexp :around #'aider--safe-get-start-fence-regexp)
+(advice-add 'markdown-syntax-propertize-fenced-block-constructs :around #'aider--safe-syntax-propertize-fenced-block-constructs)
+
+(defun aider--apply-markdown-highlighting ()
+  "Set up markdown highlighting for aider buffer with optimized performance."
+  (set-syntax-table (make-syntax-table markdown-mode-syntax-table))
+  (setq-local syntax-propertize-function #'markdown-syntax-propertize)
+  (setq-local font-lock-defaults
+              '(markdown-mode-font-lock-keywords nil nil nil nil
+                (font-lock-multiline . t)
+                (font-lock-extra-managed-props . (composition display invisible))))
+  (setq-local markdown-fontify-code-blocks-natively t)
+  (setq-local markdown-regex-italic "\\`never-match-this-pattern\\'")
+  (setq-local markdown-regex-bold "\\`never-match-this-pattern\\'")
+  (setq-local font-lock-multiline t)
+  (setq-local jit-lock-contextually nil)
+  (setq-local font-lock-support-mode 'jit-lock-mode)
+  (setq-local jit-lock-defer-time 0)
+  (font-lock-mode 1)
+  (font-lock-flush)
+  (font-lock-ensure)
+  (add-hook 'syntax-propertize-extend-region-functions
+            #'markdown-syntax-propertize-extend-region nil t)
+  (add-hook 'jit-lock-after-change-extend-region-functions
+            #'markdown-font-lock-extend-region-function t t)
+  (setq-local markdown-regex-blockquote "^\\_>$")
+  (if markdown-hide-markup
+      (add-to-invisibility-spec 'markdown-markup)
+    (remove-from-invisibility-spec 'markdown-markup)))
+
+(provide 'aider-comint-markdown)
+;;; aider-comint-markdown.el ends here

--- a/aider-core.el
+++ b/aider-core.el
@@ -3,11 +3,10 @@
 
 (require 'comint)
 (require 'magit)
-(require 'aider-comint-markdown)  ;; for markdown advice & highlighting
 (require 'savehist)
-(require 'markdown-mode)
 
 (require 'aider-utils)
+(require 'aider-comint-markdown)  ;; for markdown advice & highlighting
 
 (declare-function evil-define-key* "evil" (state map key def))
 
@@ -41,8 +40,6 @@ The format will be *aider:<git-repo-path>:<branch-name>*."
   "Boolean controlling Aider buffer display behavior.
 When non-nil, open Aider buffer in a new frame.
 When nil, use standard `display-buffer' behavior.")
-
-;; Removed: moved to aider-comint-markdown.el
 
 (defvar aider-comint-mode-map
   (let ((map (make-sparse-keymap)))
@@ -85,8 +82,6 @@ When nil, use standard `display-buffer' behavior.")
     "/voice" "/web")
   "A list of common Aider commands for completion.")
 
-;; Removed: moved to aide-comint-markdown.el
-
 (define-derived-mode aider-comint-mode comint-mode "Aider Session"
   "Major mode for interacting with Aider.
 Inherits from `comint-mode' with some Aider-specific customizations.
@@ -119,10 +114,7 @@ Inherits from `comint-mode' with some Aider-specific customizations.
                       (or history-file-path "its determined location") ; provide file path if available
                       (error-message-string err)))))) ; display the error message
 
-;; Move markdown highlighting setup to separate module
 (add-hook 'aider-comint-mode-hook #'aider--apply-markdown-highlighting)
-
-;; History functions have been moved to aider-utils.el.
 
 ;;;###autoload
 (defun aider-plain-read-string (prompt &optional initial-input candidate-list)
@@ -146,8 +138,6 @@ This function combines candidate-list with history for better completion."
 (eval-and-compile
   ;; Ensure the alias is always available in both compiled and interpreted modes.
   (defalias 'aider-read-string #'aider-plain-read-string))
-
-;; Function `aider--process-message-if-multi-line` moved to aider-utils.el.
 
 (defun aider--comint-send-string-syntax-highlight (buffer text)
   "Send TEXT to the comint BUFFER using comint's standard input mechanism.
@@ -330,8 +320,6 @@ invoke `aider-core-insert-prompt`."
     (let ((line-content (buffer-substring-no-properties (line-beginning-position) (point))))
       (when (string-match-p "^[ \t]*\\(/ask\\|/code\\|/architect\\) $" line-content)
         (aider-core-insert-prompt)))))
-
-;; Validator functions moved to aider-utils.el.
 
 (provide 'aider-core)
 

--- a/aider-core.el
+++ b/aider-core.el
@@ -1,5 +1,13 @@
 ;;; aider-core.el --- Core functionality for Aider -*- lexical-binding: t; -*-
-;;; Commentary: moved markdown highlighting and advice to aider-comint-markdown.el
+
+;; Author: Kang Tu <tninja@gmail.com>
+
+;; SPDX-License-Identifier: Apache-2.0
+
+;;; Commentary:
+;; This file provides core functionality for the Aider package.
+
+;;; Code:
 
 (require 'comint)
 (require 'magit)

--- a/aider-core.el
+++ b/aider-core.el
@@ -42,51 +42,7 @@ The format will be *aider:<git-repo-path>:<branch-name>*."
 When non-nil, open Aider buffer in a new frame.
 When nil, use standard `display-buffer' behavior.")
 
-;; Workaround: make markdown functions safe only in aider-comint-mode buffers
-;; Addressing: 1. https://github.com/tninja/aider.el/issues/159; 2. https://github.com/MatthewZMD/aidermacs/issues/141
-(defun aider--safe-maybe-funcall-regexp (origfn object &optional arg)
-  "Call ORIGFN (`markdown-maybe-funcall-regexp') safely in aider buffers only."
-  (if (eq major-mode 'aider-comint-mode)
-      (condition-case nil
-          (cond ((functionp object)
-                 (condition-case nil
-                     (if arg (funcall object arg) (funcall object))
-                   (error "")))  ; Return empty string if function call fails
-                ((stringp object) object)
-                ((null object) "")  ; Handle nil objects
-                (t ""))  ; Return empty string for any other type
-        (error ""))
-    ;; In non-aider buffers, call original function normally
-    (funcall origfn object arg)))
-
-(defun aider--safe-get-start-fence-regexp (origfn &rest args)
-  "Safely call `markdown-get-start-fence-regexp' in aider buffers only."
-  (if (eq major-mode 'aider-comint-mode)
-      (condition-case nil
-          (let ((result (apply origfn args)))
-            (if (and result (stringp result) (not (string-empty-p result)))
-                result
-              "\\`never-match\\`"))  ; Return non-matching regex if result is invalid
-        (error "\\`never-match\\`"))
-    ;; In non-aider buffers, call original function normally
-    (apply origfn args)))
-
-(defun aider--safe-syntax-propertize-fenced-block-constructs (origfn start end)
-  "Safely call `markdown-syntax-propertize-fenced-block-constructs' in aider buffers only."
-  (if (eq major-mode 'aider-comint-mode)
-      (condition-case nil
-          (funcall origfn start end)
-        (error nil))  ; Silently ignore errors in aider buffers
-    ;; In non-aider buffers, call original function normally
-    (funcall origfn start end)))
-
-;; Apply advice globally but they only activate in aider-comint-mode
-(advice-add 'markdown-maybe-funcall-regexp
-            :around #'aider--safe-maybe-funcall-regexp)
-(advice-add 'markdown-get-start-fence-regexp
-            :around #'aider--safe-get-start-fence-regexp)
-(advice-add 'markdown-syntax-propertize-fenced-block-constructs
-            :around #'aider--safe-syntax-propertize-fenced-block-constructs)
+;; Removed: moved to aider-comint-markdown.el
 
 (defvar aider-comint-mode-map
   (let ((map (make-sparse-keymap)))

--- a/aider-core.el
+++ b/aider-core.el
@@ -13,6 +13,7 @@
 (require 'magit)
 (require 'savehist)
 (require 'markdown-mode)
+(require 'aider-utils)
 
 (declare-function evil-define-key* "evil" (state map key def))
 
@@ -335,16 +336,7 @@ Otherwise, it uses *aider:<git-repo-path>* or *aider:<current-file-directory>*."
      (t
       (error "Aider: Not in a git repository and current buffer is not associated with a file")))))
 
-(defun aider--process-message-if-multi-line (str)
-  "Entering multi-line chat messages.
-https://aider.chat/docs/usage/commands.html#entering-multi-line-chat-messages
-If STR contains newlines, wrap it in {aider\\nstr\\naider}.
-Otherwise return STR unchanged."
-  ;; Only wrap if contains newline and not already wrapped with \"{aider\"
-  (if (and (string-match-p "\n" str)
-           (not (string-match-p "{aider" str)))
-      (format "{aider\n%s\naider}" str)
-    str))
+;; Function `aider--process-message-if-multi-line` moved to aider-utils.el.
 
 (defun aider--comint-send-string-syntax-highlight (buffer text)
   "Send TEXT to the comint BUFFER using comint's standard input mechanism.
@@ -586,40 +578,7 @@ invoke `aider-core-insert-prompt`."
       (when (string-match-p "^[ \t]*\\(/ask\\|/code\\|/architect\\) $" line-content)
         (aider-core-insert-prompt)))))
 
-;; validators
-
-(defun aider--validate-buffer-file ()
-  "Validate that current buffer is associated with a file.
-Returns `buffer-file-name` if valid, nil otherwise with message."
-  (if buffer-file-name
-      buffer-file-name
-    (message "Current buffer is not associated with a file")
-    nil))
-
-(defun aider--validate-git-repository ()
-  "Validate that we're in a git repository and return git root.
-Returns git root if valid, nil otherwise with message."
-  (let ((git-root (magit-toplevel)))
-    (if git-root
-        git-root
-      (message "Not in a git repository")
-      nil)))
-
-(defun aider--validate-aider-buffer ()
-  "Validate that aider buffer exists and has an active process.
-Returns the aider buffer if valid, otherwise returns nil with message."
-  (let ((buffer-name (aider-buffer-name)))
-    (cond
-     ((not (get-buffer buffer-name))
-      (message "Aider buffer does not exist. Please start 'aider' first")
-      nil)
-     (t
-      (let* ((aider-buffer (get-buffer buffer-name))
-             (aider-process (get-buffer-process aider-buffer)))
-        (if (and aider-process (comint-check-proc aider-buffer))
-            aider-buffer
-          (message "No active process found in aider buffer: %s" buffer-name)
-          nil))))))
+;; Validator functions moved to aider-utils.el.
 
 (provide 'aider-core)
 

--- a/aider-prompt-mode.el
+++ b/aider-prompt-mode.el
@@ -10,6 +10,7 @@
 ;;; Code:
 
 (require 'org)
+
 (require 'aider-core)
 
 (defvar yas-snippet-dirs)

--- a/aider-utils.el
+++ b/aider-utils.el
@@ -1,6 +1,7 @@
 ;;; aider-utils.el --- Utility functions for Aider -*- lexical-binding: t; -*-
 
-;; Author: extracted from aider-core.el
+;; Author: Kang Tu <tninja@gmail.com>
+
 ;; SPDX-License-Identifier: Apache-2.0
 
 ;;; Commentary:

--- a/aider-utils.el
+++ b/aider-utils.el
@@ -1,0 +1,119 @@
+;;; aider-utils.el --- Utility functions for Aider -*- lexical-binding: t; -*-
+
+;; Author: extracted from aider-core.el
+;; SPDX-License-Identifier: Apache-2.0
+
+(require 'magit)
+(require 'subr-x)
+
+;;; Git & path utilities
+
+(defun aider--get-git-repo-root ()
+  "Return the top-level directory of the current git repository, or nil."
+  (let ((git-root (magit-toplevel)))
+    (when (and git-root (stringp git-root) (not (string-match-p "fatal" git-root)))
+      (file-truename git-root))))
+
+(defun aider--get-relevant-directory-for-history ()
+  "Return the top-level directory of the current git repository.
+If not in a git repo, return the directory of the current buffer's file.
+Returns nil if neither can be determined."
+  (or (aider--get-git-repo-root)
+      (when-let ((bfn (buffer-file-name)))
+        (file-name-directory (file-truename bfn)))))
+
+(defun aider--generate-history-file-name ()
+  "Generate path for .aider.input.history in git repo root or current buffer's dir."
+  (when-let ((relevant-dir (aider--get-relevant-directory-for-history)))
+    (expand-file-name ".aider.input.history" relevant-dir)))
+
+;;; History parsing
+
+(defun aider--parse-aider-cli-history (file-path)
+  "Parse .aider.input.history file at FILE-PATH.
+Return a list of commands, oldest to newest."
+  (when (and file-path (file-readable-p file-path))
+    (with-temp-buffer
+      (insert-file-contents file-path)
+      (let ((history-items '())
+            (current-multi-line-command-parts nil))
+        (goto-char (point-min))
+        (while (not (eobp))
+          (let ((line (buffer-substring-no-properties
+                       (line-beginning-position)
+                       (line-end-position))))
+            (when (string-match "^\\+[ \t]*\\(.*\\)" line)
+              (let ((content (match-string 1 line)))
+                (cond
+                 ((string= content "{aider")
+                  (setq current-multi-line-command-parts (list content)))
+                 ((string= content "aider}")
+                  (if current-multi-line-command-parts
+                      (progn
+                        (setq current-multi-line-command-parts
+                              (nconc current-multi-line-command-parts (list content)))
+                        (push (string-join current-multi-line-command-parts "\n")
+                              history-items)
+                        (setq current-multi-line-command-parts nil))
+                    (push content history-items)))
+                 (current-multi-line-command-parts
+                  (setq current-multi-line-command-parts
+                        (nconc current-multi-line-command-parts (list content))))
+                 (t
+                  (push content history-items))))))
+          (forward-line 1))
+        (when current-multi-line-command-parts
+          (push (string-join current-multi-line-command-parts "\n")
+                history-items))
+        (reverse history-items)))))
+
+;;; Message formatting
+
+(defun aider--process-message-if-multi-line (str)
+  "Entering multi-line chat messages.
+https://aider.chat/docs/usage/commands.html#entering-multi-line-chat-messages
+If STR contains newlines, wrap it in {aider\\nstr\\naider}.
+Otherwise return STR unchanged."
+  (if (and (string-match-p "\n" str)
+           (not (string-match-p "{aider" str)))
+      (format "{aider\n%s\naider}" str)
+    str))
+
+;;; Validators
+
+(defun aider--validate-buffer-file ()
+  "Validate that current buffer is associated with a file.
+Returns `buffer-file-name` if valid, nil otherwise with message."
+  (if buffer-file-name
+      buffer-file-name
+    (message "Current buffer is not associated with a file")
+    nil))
+
+(defun aider--validate-git-repository ()
+  "Validate that we're in a git repository and return git root.
+Returns git root if valid, nil otherwise with message."
+  (let ((git-root (magit-toplevel)))
+    (if git-root
+        git-root
+      (message "Not in a git repository")
+      nil)))
+
+(defun aider--validate-aider-buffer ()
+  "Validate that aider buffer exists and has an active process.
+Returns the aider buffer if valid, otherwise returns nil with message."
+  (let ((buffer-name (aider-buffer-name)))
+    (cond
+     ((not (get-buffer buffer-name))
+      (message "Aider buffer does not exist. Please start 'aider' first")
+      nil)
+     (t
+      (let* ((aider-buffer (get-buffer buffer-name))
+             (aider-process (get-buffer-process aider-buffer)))
+        (if (and aider-process (comint-check-proc aider-buffer))
+            aider-buffer
+          (message "No active process found in aider buffer: %s" buffer-name)
+          nil))))))
+
+(provide 'aider-utils)
+
+;;; aider-utils.el ends here

--- a/aider-utils.el
+++ b/aider-utils.el
@@ -3,8 +3,14 @@
 ;; Author: extracted from aider-core.el
 ;; SPDX-License-Identifier: Apache-2.0
 
+;;; Commentary:
+;; Utility functions for the Aider package.
+
+;;; Code:
+
 (require 'magit)
 (require 'subr-x)
+(declare-variable aider-use-branch-specific-buffers)
 
 ;;; Git & path utilities
 


### PR DESCRIPTION
aider-core.el grow large and less easy to maintain / develop. This refactor is about to make code more modular.