### PR TITLE
Feat: add optional keyword filter to git log analysis in aider-magit-log-analyze

### DIFF
--- a/aider-git.el
+++ b/aider-git.el
@@ -299,6 +299,10 @@ generate the log, save it to 'PROJECT_ROOT/git.log', open this file, and then an
          ;; Define the expected path for git.log at the project root
          (project-log-file-path (expand-file-name "git.log" git-root))
          keyword)
+    ;; Always ask for an optional keyword, even if we're already visiting git.log
+    (setq keyword
+          (read-string
+           "Optional: Keyword to filter commits (leave empty for no filter): "))
     (if (not (and buffer-file-name
                   (string-equal (file-name-nondirectory buffer-file-name) "git.log")
                   ;; Optional: more strictly check if it's the project's git.log
@@ -309,8 +313,7 @@ generate the log, save it to 'PROJECT_ROOT/git.log', open this file, and then an
         ;; Not a git.log file, or no file associated with buffer, or not the project's git.log
         (let* ((num-commits-str (read-string (format "Number of commits to fetch for %s (default 100): " repo-name) "100"))
                (num-commits (if (string-empty-p num-commits-str) "100" num-commits-str)))
-          (setq keyword (read-string "Optional: Keyword to filter commits (leave empty for no filter): "))
-          (message "Fetching Git log for %s (%s commits with stats%s)... This might take a moment."
+          (message "Fetching Git log for %s (%s commits%s)... This might take a moment."
                    repo-name num-commits (if (string-empty-p keyword) "" (format " filtered by keyword '%s'" keyword)))
           (setq log-output (if (string-empty-p keyword)
                                (magit-git-output "log" "--pretty=medium" "--stat" "-n" num-commits)

--- a/aider-git.el
+++ b/aider-git.el
@@ -255,7 +255,6 @@ code evolution and the reasoning behind changes."
   (interactive)
   (when (aider--validate-buffer-file)
   (let* ((file-path (buffer-file-name))
-         (file-name (file-name-nondirectory file-path))
          (has-region (use-region-p))
          (line-start (if has-region
                          (line-number-at-pos (region-beginning))
@@ -301,7 +300,7 @@ Returns the path to the git.log file."
     (with-temp-file project-log-file-path
       (insert log-output))
     (find-file project-log-file-path)
-    project-log-file-path)
+    project-log-file-path))
 
 (defun aider--default-log-analysis-instructions (keyword)
   "Return the default analysis prompt for KEYWORD (may be empty)."

--- a/aider-git.el
+++ b/aider-git.el
@@ -328,12 +328,13 @@ generate the log, save it to 'PROJECT_ROOT/git.log', open this file, and then an
            (default-analysis
             (if (not (string-empty-p keyword))
                 (format "Analyze the commits filtered by keyword '%s'. Provide insights on:\n\
-1. Frequency and patterns of '%s' related commits.\n\
-2. Files or areas most impacted by '%s' changes.\n\
-3. Main contributors and their roles in '%s' work.\n\
-4. Trends or hotspots in '%s' related development.\n\
-5. Suggestions for improving or refactoring '%s' implementation.\n"
-                        keyword keyword keyword keyword keyword keyword)
+1. Overall '%s' related feature evolution and major development phases, with author name in each phase.\n\
+2. Frequency and patterns of '%s' related commits.\n\
+3. Files or areas most impacted by '%s' changes.\n\
+4. Main contributors and their roles in '%s' work.\n\
+5. Trends or hotspots in '%s' related development.\n\
+6. Suggestions for improving or refactoring '%s' implementation.\n"
+                        keyword keyword keyword keyword keyword keyword keyword)
               (concat "Please analyze the following Git log for the entire repository. Provide insights on:\n"
                       "1. Overall project evolution and major development phases, with author name in each phase.\n"
                       "2. Identification of key features, refactorings, or architectural changes and their timeline, with author name for each one.\n"


### PR DESCRIPTION
In case user want to understand git commits related to a particular topic