### PR TITLE
Feat: aider-function-or-region-change (C-c a r) support inline comment based existing code change requirement

### DIFF
--- a/HISTORY.org
+++ b/HISTORY.org
@@ -1,6 +1,10 @@
 
 * Release history
 
+** Main branch change
+
+- Feat: aider-function-or-region-change (C-c a r) support inline comment based existing code change requirement
+
 ** v0.12.2
 
 - Feat: Prefer feature branch for code change, protect main/master/develop branch from code change

--- a/README.org
+++ b/README.org
@@ -119,13 +119,17 @@ If you used installed aider.el through melpa and package-install, just need to ~
   - aider-add-files-in-current-window :: Add all buffers in the current window.
 
 *** Write code
-  - aider-function-or-region-change :: If a region is selected, ask Aider to change the selected region. Otherwise, ask Aider to change / change the function under the cursor.
-    - A couple common used prompts provided when you are using aider-helm.el
   - aider-implement-todo :: Implement requirement in comments in-place, in current context.
     - If cursor is on a comment line, implement that specific comment in-place.
     - If there is a selection region of multi-line comments, implement code for those comments in-place.
     - If cursor is inside a function, implement TODOs for that function, otherwise implement TODOs for the entire current file.
       - The keyword (TODO by default) can be customized with the variable ~aider-todo-keyword-pair~. One example is to use AI! comment, which is as same as aider AI comment feature.
+  - aider-function-or-region-change :: If a region is selected, ask Aider to change the selected region. Otherwise, ask Aider to change / change the function under the cursor.
+    - A couple common used prompts provided when you are using aider-helm.el
+    - It support inline comment based existing code change requirement. To use this feature:
+      - Write a single line comment to describe the desired change for the current function (if the comment is in a function), or change on current added files (outside of a function).
+      - When the cursor is on the comment, type C-c a r, it will compose a prompt given the requirement in the comment, and then send to aider
+      - Review the code change, and accept it if you are happy with it.
 
 *** Support for Agile Development
   - aider-write-unit-test :: If the current buffer is main source code file, generate comprehensive unit tests for the current function or file. If the cursor is in a test source code file, when the cursor is on a test function, implement the test function. Otherwise, provide description to implement the test function (or spec).

--- a/README.org
+++ b/README.org
@@ -119,7 +119,7 @@ If you used installed aider.el through melpa and package-install, just need to ~
   - aider-add-files-in-current-window :: Add all buffers in the current window.
 
 *** Write code
-  - aider-function-or-region-refactor :: If a region is selected, ask Aider to refactor the selected region. Otherwise, ask Aider to change / refactor the function under the cursor.
+  - aider-function-or-region-change :: If a region is selected, ask Aider to change the selected region. Otherwise, ask Aider to change / change the function under the cursor.
     - A couple common used prompts provided when you are using aider-helm.el
   - aider-implement-todo :: Implement requirement in comments in-place, in current context.
     - If cursor is on a comment line, implement that specific comment in-place.
@@ -129,7 +129,7 @@ If you used installed aider.el through melpa and package-install, just need to ~
 
 *** Support for Agile Development
   - aider-write-unit-test :: If the current buffer is main source code file, generate comprehensive unit tests for the current function or file. If the cursor is in a test source code file, when the cursor is on a test function, implement the test function. Otherwise, provide description to implement the test function (or spec).
-  - If main source code break and test function fails, use ~aider-function-or-region-refactor~ on the failed test function to ask Aider to fix the code to make the test pass.
+  - If main source code break and test function fails, use ~aider-function-or-region-change~ on the failed test function to ask Aider to fix the code to make the test pass.
   - aider-refactor-book-method :: for code refactoring using techniques from [[https://www.amazon.com/Refactoring-Improving-Existing-Addison-Wesley-Signature/dp/0134757599/ref=asc_df_0134757599?mcid=2eb8b1a5039a3b7c889ee081fc2132e0&hvocijid=16400341203663661896-0134757599-&hvexpln=73&tag=hyprod-20&linkCode=df0&hvadid=721245378154&hvpos=&hvnetw=g&hvrand=16400341203663661896&hvpone=&hvptwo=&hvqmt=&hvdev=c&hvdvcmdl=&hvlocint=&hvlocphy=9032161&hvtargid=pla-2281435180458&psc=1][Martin Flower's Refactoring book]], you can also let AI make the decision on how to refactor, example: [[https://github.com/tninja/aider.el/pull/146/commits/811a8eca47dfba3c52a33afba7bb11a8a69689b1][this commit]] addressing [[https://github.com/tninja/aider.el/pull/146#discussion_r2078182430][this comment]]
   - aider-pull-or-review-diff-file :: let aider to pull and review the code change.
 

--- a/README.zh-cn.org
+++ b/README.zh-cn.org
@@ -160,7 +160,7 @@ Helm 为命令历史提示启用模糊搜索功能。由于我们很可能会使
   - aider-add-files-in-current-window :: 添加当前窗口中的所有缓冲区。
 
 *** 编写代码
-  - aider-function-or-region-refactor :: 如果选择了区域，要求 Aider 重构所选区域。否则，要求 Aider 更改/重构光标下的函数。
+  - aider-function-or-region-change :: 如果选择了区域，要求 Aider 重构所选区域。否则，要求 Aider 更改/重构光标下的函数。
     - 当您使用 aider-helm.el 时，会提供几个常用的提示
   - aider-implement-todo :: 在当前上下文中就地实现注释中的需求。
     - 如果光标在注释行上，就地实现该特定注释。
@@ -170,7 +170,7 @@ Helm 为命令历史提示启用模糊搜索功能。由于我们很可能会使
 
 *** 支持敏捷开发
   - aider-write-unit-test :: 如果当前缓冲区是主源代码文件，为当前函数或文件生成全面的单元测试。如果光标在测试源代码文件中，当光标在测试函数上时，实现该测试函数。否则，提供描述来实现测试函数（或规范）。
-  - 如果主源代码出现问题且测试函数失败，可以在失败的测试函数上使用 ~aider-function-or-region-refactor~ 要求 Aider 修复代码以使测试通过。
+  - 如果主源代码出现问题且测试函数失败，可以在失败的测试函数上使用 ~aider-function-or-region-change~ 要求 Aider 修复代码以使测试通过。
   - aider-refactor-book-method :: 使用 [[https://www.amazon.com/Refactoring-Improving-Existing-Addison-Wesley-Signature/dp/0134757599/ref=asc_df_0134757599?mcid=2eb8b1a5039a3b7c889ee081fc2132e0&hvocijid=16400341203663661896-0134757599-&hvexpln=73&tag=hyprod-20&linkCode=df0&hvadid=721245378154&hvpos=&hvnetw=g&hvrand=16400341203663661896&hvpone=&hvptwo=&hvqmt=&hvdev=c&hvdvcmdl=&hvlocint=&hvlocphy=9032161&hvtargid=pla-2281435180458&psc=1][Martin Flower 的重构书籍]] 中的技术进行代码重构，您也可以让 AI 决定如何重构，示例：[[https://github.com/tninja/aider.el/pull/146/commits/811a8eca47dfba3c52a33afba7bb11a8a69689b1][此提交]] 解决了 [[https://github.com/tninja/aider.el/pull/146#discussion_r2078182430][此评论]]
   - aider-pull-or-review-diff-file :: 让 aider 拉取并审查代码更改。
 
@@ -269,7 +269,7 @@ Helm 为命令历史提示启用模糊搜索功能。由于我们很可能会使
 ** 一个弱 [[https://en.wikipedia.org/wiki/Test-driven_development][TDD]] 风格的 AI 编程工作流
 
 1. **实施或修改代码**：
-   - 对于现有代码：在函数中使用光标或在选定区域上使用 ~aider-function-or-region-refactor~
+   - 对于现有代码：在函数中使用光标或在选定区域上使用 ~aider-function-or-region-change~
    - 对于新代码：在 TODO 注释上使用 ~aider-implement-todo~
 
    *添加新代码的示例*：

--- a/aider-code-change.el
+++ b/aider-code-change.el
@@ -42,7 +42,7 @@ Another common choice is (\"AI!\" . \"comment line ending with string: AI!\")."
   (let ((command (aider-read-string "Enter architectural discussion topic/question: ")))
     (aider-current-file-command-and-switch "/architect " command)))
 
-(defun aider-region-refactor-generate-command (region-text function-name user-command)
+(defun aider-region-change-generate-command (region-text function-name user-command)
   "Generate the command string based on input parameters.
 REGION-TEXT, FUNCTION-NAME, and USER-COMMAND."
   (let ((processed-region-text region-text))
@@ -54,7 +54,7 @@ REGION-TEXT, FUNCTION-NAME, and USER-COMMAND."
 
 (defun aider--handle-comment-requirement (line-text function-name)
   "Handle a standalone comment requirement at point.
-Delete the comment line, prompt for instruction, and send refactor command."
+Delete the comment line, prompt for instruction, and send change command."
   (let* ((req (replace-regexp-in-string
                (concat "^[ \t]*"
                        (regexp-quote (string-trim-right comment-start))
@@ -76,7 +76,7 @@ Delete the comment line, prompt for instruction, and send refactor command."
     (aider--send-command cmd t)))
 
 (defun aider--handle-region-or-function (region-active function-name)
-  "Handle refactoring of selected region or containing function."
+  "Handle changeing of selected region or containing function."
   (let* ((region-text (and region-active
                            (buffer-substring-no-properties
                             (region-beginning)
@@ -88,16 +88,16 @@ Delete the comment line, prompt for instruction, and send refactor command."
                   (function-name
                    (format "Change %s: " function-name))
                   (region-active
-                   "Refactor instruction for selected region: ")
+                   "Change instruction for selected region: ")
                   (t
-                   "Refactor instruction: ")))
+                   "Change instruction: ")))
          (is-test-file (and buffer-file-name
                             (string-match-p "test"
                                             (file-name-nondirectory
                                              buffer-file-name))))
          (candidate-list (if is-test-file
                              '("Write a new unit test function based on the given description."
-                               "Refactor this test, using better testing patterns, reducing duplication, and improving readability and maintainability. Maintain the current functionality of the tests."
+                               "Change this test, using better testing patterns, reducing duplication, and improving readability and maintainability. Maintain the current functionality of the tests."
                                "This test failed. Please analyze and fix the source code functions to make this test pass without changing the test itself. Don't break any other test"
                                "Improve test assertions and add edge cases."
                                "Extract this logic into a separate helper function")
@@ -113,22 +113,22 @@ Delete the comment line, prompt for instruction, and send refactor command."
          (instruction (aider-read-string prompt nil candidate-list)))
     (cond
      (region-active
-      (let ((command (aider-region-refactor-generate-command
+      (let ((command (aider-region-change-generate-command
                       region-text function-name instruction)))
         (aider-add-current-file)
         (aider--send-command command t)))
      (function-name
       (when (aider-current-file-command-and-switch
              "/architect "
-             (concat (format "refactor %s: " function-name)
+             (concat (format "change %s: " function-name)
                      instruction))
         (message "Code change request sent to Aider"))))))
 
 ;;;###autoload
-(defun aider-function-or-region-refactor ()
-  "Refactor code under cursor or in selected region.
-If a region is selected, refactor that specific region.
-Otherwise, refactor the function under cursor.
+(defun aider-function-or-region-change ()
+  "Change code under cursor or in selected region.
+If a region is selected, change that specific region.
+Otherwise, change the function under cursor.
 Additionally, if cursor is on a standalone comment line (and no region),
 treat that comment as the requirement, remove it, and send it."
   (interactive)

--- a/aider-core.el
+++ b/aider-core.el
@@ -86,7 +86,7 @@ When nil, use standard `display-buffer' behavior.")
 (defun aider-go-ahead ()
   "Send the command \"go ahead\" to the corresponding aider comint buffer."
   (interactive)
-  (aider--send-command "go ahead" t))
+  (aider--send-command "/code go ahead" t))
 
 (defconst aider--command-list
   '("/add" "/architect" "/ask" "/code" "/reset" "/undo" "/lint" "/read-only"

--- a/aider-doom.el
+++ b/aider-doom.el
@@ -49,7 +49,7 @@
                     :desc "File Evolution Analysis" "b" #'aider-magit-blame-analyze)
 
                    (:prefix ("c" . "Code")
-                    :desc "Change Function/Region" "r" #'aider-function-or-region-refactor
+                    :desc "Change Function/Region" "r" #'aider-function-or-region-change
                     :desc "Implement Requirement" "i" #'aider-implement-todo
                     :desc "Architect Discuss/Change" "t" #'aider-architect-discussion
                     :desc "Write Unit Test" "U" #'aider-write-unit-test

--- a/aider.el
+++ b/aider.el
@@ -115,7 +115,7 @@ Also based on aider LLM benchmark: https://aider.chat/docs/leaderboards/"
 
 ;;; Transient menu items for the “Code Change” section.
 (transient-define-group aider--menu-code-change
-  ("r" "Change Function/Region"      aider-function-or-region-refactor)
+  ("r" "Change Function/Region"      aider-function-or-region-change)
   ("i" "Implement Requirement"       aider-implement-todo)
   ("t" "Architect Discuss/Change"    aider-architect-discussion)
   ("U" "Write Unit Test"             aider-write-unit-test)

--- a/appendix.org
+++ b/appendix.org
@@ -127,7 +127,7 @@ The aider prefix is ~A~.
 ** A weak [[https://en.wikipedia.org/wiki/Test-driven_development][TDD]] style AI programming workflow
 
 1. *Implement or modify code*
-   - For existing code: Use ~aider-function-or-region-refactor~ with cursor in function or on selected region
+   - For existing code: Use ~aider-function-or-region-change~ with cursor in function or on selected region
    - For new code: Use ~aider-implement-todo~ on TODO comments
    
    *Example of adding new code*:


### PR DESCRIPTION
This new feature is similar to existing aider-implement-todo, the difference is aider-implement-todo is about to add new code, aider-function-or-region-change is to modify existing code. To use this feature, user just need to:

1. Write a single line comment to describe the desired change for the current function (if the comment is in a function), or change on current added files (outside of a function). Example below:
![Screenshot from 2025-06-21 11-32-38](https://github.com/user-attachments/assets/3660b82e-be4a-473e-8ebd-8b3fb6258f31)

2. When the cursor is on the comment, type C-c a r, it will compose a prompt given the requirement in the comment, and then send to aider
![Screenshot from 2025-06-21 11-34-30](https://github.com/user-attachments/assets/852c77c7-adfb-4d75-9dc3-76a8f37d5c60)

3. Review the code change, and accept it if you are happy with it.

This change unified the ways to input requirement with inline comment to 1. add new code; 2. modify existing code. It simplify the input interface. 

The prompt will also be in the mini buffer / helm history for the future reuse.

Related topic:
1. https://github.com/tninja/aider.el/issues/25
2. https://github.com/tninja/aider.el/issues/156

Breaking change is to rename aider-function-or-region-refactor to aider-function-or-region-change. Since the function is not limited to refactoring. It is initial naming error. For code refactoring, aider-refactor-book-method (C-c a R) are more comprehensive on this particular topic.