### PR TITLE
Chore: Couple of small changes

### DIFF
--- a/HISTORY.org
+++ b/HISTORY.org
@@ -3,7 +3,7 @@
 
 ** Main branch change
 
-- Feat: aider-function-or-region-change (C-c a r) support inline comment based existing code change requirement, when
+- Feat: aider-function-or-region-change (C-c a c) support inline comment based existing code change requirement, when
   - The current line is a comment describing the change
   - the current selected region is multi-line comments describing the change
 - Improve aider-magit-log-analyze

--- a/aider-core.el
+++ b/aider-core.el
@@ -261,7 +261,10 @@ Return potentially modified CURRENT-ARGS."
                            (read-string "Edit aider arguments: "
                                         (mapconcat #'identity aider-args " ")))
                         aider-args)))
-    ;; automatically add --no-auto-accept-architect if there is no --auto-accept-architect and --no-auto-accept-architect
+    ;; 如果既没有 --auto-accept-architect 也没有 --no-auto-accept-architect，就自动添加后者
+    (unless (or (member "--auto-accept-architect" current-args)
+                (member "--no-auto-accept-architect" current-args))
+      (setq current-args (append current-args '("--no-auto-accept-architect"))))
     ;; Handle --subtree-only prompting for special modes
     (setq current-args (aider--maybe-prompt-subtree-only-for-special-modes current-args))
     ;; Add --subtree-only if the parameter is set and it's not already present

--- a/aider-core.el
+++ b/aider-core.el
@@ -261,7 +261,6 @@ Return potentially modified CURRENT-ARGS."
                            (read-string "Edit aider arguments: "
                                         (mapconcat #'identity aider-args " ")))
                         aider-args)))
-    ;; 如果既没有 --auto-accept-architect 也没有 --no-auto-accept-architect，就自动添加后者
     (unless (or (member "--auto-accept-architect" current-args)
                 (member "--no-auto-accept-architect" current-args))
       (setq current-args (append current-args '("--no-auto-accept-architect"))))

--- a/aider-core.el
+++ b/aider-core.el
@@ -261,6 +261,7 @@ Return potentially modified CURRENT-ARGS."
                            (read-string "Edit aider arguments: "
                                         (mapconcat #'identity aider-args " ")))
                         aider-args)))
+    ;; automatically add --no-auto-accept-architect if there is no --auto-accept-architect and --no-auto-accept-architect
     ;; Handle --subtree-only prompting for special modes
     (setq current-args (aider--maybe-prompt-subtree-only-for-special-modes current-args))
     ;; Add --subtree-only if the parameter is set and it's not already present

--- a/aider-doom.el
+++ b/aider-doom.el
@@ -33,39 +33,40 @@
                     :desc "Run Aider (C-u: args)" "a" #'aider-run-aider
                     :desc "Switch to Aider Buffer" "z" #'aider-switch-to-buffer
                     :desc "Input with Repo Prompt File" "p" #'aider-open-prompt-file
+                    :desc "Create / Checkout Branch" "c" #'magit-branch-or-checkout
                     :desc "Reset Aider (C-u: clear)" "s" #'aider-reset
-                    :desc "Select Model (C-u: leaderboard)" "o" #'aider-change-model
-                    :desc "Clear Aider buffer" "c" #'aider-clear-buffer
-                    :desc "Exit Aider" "x" #'aider-exit)
+                    :desc "Select Model (C-u: benchmark)" "o" #'aider-change-model
+                    :desc "Exit Aider" "X" #'aider-exit)
 
                    (:prefix ("f" . "Files")
                     :desc "Add Current/Marked File (C-u: readonly)" "f" #'aider-add-current-file-or-dired-marked-files
                     :desc "Add All Files in Window" "w" #'aider-add-files-in-current-window
                     :desc "Add Module w/o grep (C-u: readonly)" "M" #'aider-add-module
-                    :desc "Drop Current File" "O" #'aider-drop-current-file
+                    :desc "Drop File in Buffer / under Cursor" "O" #'aider-drop-current-file
+                    :desc "Expand Context for Current File" "x" #'aider-expand-context-current-file
                     :desc "Show Last Commit (C-u: magit-log)" "m" #'aider-magit-show-last-commit-or-log
                     :desc "Undo Last Change" "u" #'aider-undo-last-change
                     :desc "Pull or Review Code Change" "v" #'aider-pull-or-review-diff-file
-                    :desc "File Evolution Analysis" "b" #'aider-magit-blame-analyze)
+                    :desc "File Evolution Analysis (C-u: Repo)" "e" #'aider-magit-blame-or-log-analyze)
 
                    (:prefix ("c" . "Code")
-                    :desc "Change Function/Region" "r" #'aider-function-or-region-change
+                    :desc "Change Function/Region" "c" #'aider-function-or-region-change
                     :desc "Implement Requirement" "i" #'aider-implement-todo
                     :desc "Architect Discuss/Change" "t" #'aider-architect-discussion
                     :desc "Write Unit Test" "U" #'aider-write-unit-test
-                    :desc "Refactor Code" "R" #'aider-refactor-book-method
+                    :desc "Fix Flycheck Errors" "F" #'aider-flycheck-fix-errors-in-scope
+                    :desc "Refactor Code" "r" #'aider-refactor-book-method
                     :desc "Test Driven Development" "T" #'aider-tdd-cycle
                     :desc "Work with Legacy Code" "l" #'aider-legacy-code
                     :desc "Code/Doc Bootstrap" "B" #'aider-bootstrap)
 
                    (:prefix ("d" . "Discuss")
-                    :desc "Ask question" "q" #'aider-ask-question
-                    :desc "General question" "Q" #'aider-general-question
+                    :desc "Question (C-u no context)" "q" #'aider-ask-question
                     :desc "Then Go Ahead" "y" #'aider-go-ahead
                     :desc "Code Reading" "d" #'aider-code-read
-                    :desc "Copy To Clipboard" "c" #'aider-copy-to-clipboard
+                    :desc "Copy To Clipboard" "C" #'aider-copy-to-clipboard
                     :desc "Software Planning" "P" #'aider-start-software-planning
-                    :desc "Debug Exception" "e" #'aider-debug-exception
+                    :desc "Debug Exception" "E" #'aider-debug-exception
                     :desc "Open History" "h" #'aider-open-history
                     :desc "Help (C-u: homepage)" "?" #'aider-help)
 

--- a/aider.el
+++ b/aider.el
@@ -115,12 +115,12 @@ Also based on aider LLM benchmark: https://aider.chat/docs/leaderboards/"
 
 ;;; Transient menu items for the “Code Change” section.
 (transient-define-group aider--menu-code-change
-  ("r" "Change Function/Region"      aider-function-or-region-change)
+  ("c" "Change Function/Region"      aider-function-or-region-change)
   ("i" "Implement Requirement"       aider-implement-todo)
   ("t" "Architect Discuss/Change"    aider-architect-discussion)
   ("U" "Write Unit Test"             aider-write-unit-test)
   ("F" "Fix Flycheck Errors"         aider-flycheck-fix-errors-in-scope)
-  ("R" "Refactor Code"               aider-refactor-book-method)
+  ("r" "Refactor Code"               aider-refactor-book-method)
   ("T" "Test Driven Development"     aider-tdd-cycle)
   ("l" "Work with Legacy Code"       aider-legacy-code)
   ("B" "Code/Doc Bootstrap"          aider-bootstrap))


### PR DESCRIPTION
1. Automatically add --no-auto-accept-architect, unless user specify --auto-accept-architect.
2. Map aider-function-or-region-change to C-c a c instead, since it is change, not refactoring anymore. C-c a r map to aider-refactor-book-method
3. Update doom menu.