### PR TITLE
Chore: Integrate aider-function-or-region-change and aider-architect-discussion

### DIFF
--- a/HISTORY.org
+++ b/HISTORY.org
@@ -4,7 +4,7 @@
 ** Main branch change
 
 - More intelligent and simplified aider-ask-question: Do not use C-u key anymore to choose if it is a question on current function or general question. It will identify the choice given position of current cursor, if it need to ask question, use completing-reading instead of C-u
-- Integrate aider-function-or-region-change and aider-architect-discussion, similar to change above
+- Integrate aider-function-or-region-change and aider-architect-discussion, as aider-code-change function, similar to change above
 
 ** v.0.13.0
 

--- a/HISTORY.org
+++ b/HISTORY.org
@@ -4,6 +4,7 @@
 ** Main branch change
 
 - More intelligent and simplified aider-ask-question: Do not use C-u key anymore to choose if it is a question on current function or general question. It will identify the choice given position of current cursor, if it need to ask question, use completing-reading instead of C-u
+- Integrate aider-function-or-region-change and aider-architect-discussion, similar to change above
 
 ** v.0.13.0
 

--- a/README.org
+++ b/README.org
@@ -133,12 +133,11 @@ If you used installed aider.el through melpa and package-install, just need to ~
     - If there is a selection region of multi-line comments, implement code for those comments in-place.
     - If cursor is inside a function, implement TODOs for that function, otherwise implement TODOs for the entire current file.
       - The keyword (TODO by default) can be customized with the variable ~aider-todo-keyword-pair~. One example is to use AI! comment, which is as same as aider AI comment feature.
-  - aider-function-or-region-change (C-c a c) :: If a region is selected, ask Aider to change the selected region. Otherwise, ask Aider to change / change the function under the cursor.
+  - aider-code-change (C-c a c) :: If a region is selected, ask Aider to change the selected region. Otherwise, ask Aider to change / change the function under the cursor, or general code change on all added files.
     - A couple common used prompts provided when you are using aider-helm.el
     - It supports inline comment based existing code change requirement. To use this feature, trigger the command when:
       - The current line is a comment describing the change
       - the current selected region is multi-line comments describing the change
-  - aider-architect-discussion (C-c a t) :: General code change request. 
   - All the above commands follows code review / apply process
 
 *** Support for Agile Development

--- a/aider-code-change.el
+++ b/aider-code-change.el
@@ -45,7 +45,7 @@ between changing the function or starting an architectural discussion."
       (let ((choice (completing-read
                      "Choose action: "
                      (list (format "Change function '%s'" function-name)
-                           "Global code change")
+                           "Architectural discussion")
                      nil t)))
         (if (string-prefix-p "Change function" choice)
             (aider-function-or-region-change)
@@ -56,8 +56,19 @@ between changing the function or starting an architectural discussion."
 (defun aider-architect-discussion ()
   "Discuss with aider with the given prompt, and choose if we want to accept it."
   (interactive)
-  (let ((command (aider-read-string "Enter architectural discussion topic/question: ")))
-    (aider-current-file-command-and-switch "/architect " command)))
+  (let* ((line-text (string-trim (thing-at-point 'line t)))
+         (is-comment (aider--is-comment-line line-text)))
+    (if is-comment
+        (let* ((req (replace-regexp-in-string
+                     (concat "^[ \t]*"
+                             (regexp-quote (string-trim-right comment-start))
+                             "+[ \t]*")
+                     ""
+                     line-text))
+               (instruction (aider-read-string "Architectural discussion topic/question: " req)))
+          (aider-current-file-command-and-switch "/architect " instruction))
+      (let ((command (aider-read-string "Enter architectural discussion topic/question: ")))
+        (aider-current-file-command-and-switch "/architect " command)))))
 
 (defun aider-region-change-generate-command (region-text function-name user-command)
   "Generate the command string based on input parameters.

--- a/aider-code-change.el
+++ b/aider-code-change.el
@@ -32,7 +32,7 @@ Another common choice is (\"AI!\" . \"comment line ending with string: AI!\")."
 If a region is selected, change that specific region.
 If cursor is not in a function, start an architectural discussion.
 If cursor is in a function without a selected region, lets user choose
-between changing the function or starting an architectural discussion."
+between changing the function or general code change."
   (interactive)
   (let* ((function-name (which-function))
          (region-active (region-active-p)))
@@ -45,7 +45,7 @@ between changing the function or starting an architectural discussion."
       (let ((choice (completing-read
                      "Choose action: "
                      (list (format "Change function '%s'" function-name)
-                           "Architectural discussion")
+                           "General code change")
                      nil t)))
         (if (string-prefix-p "Change function" choice)
             (aider-function-or-region-change)

--- a/aider-code-change.el
+++ b/aider-code-change.el
@@ -26,13 +26,30 @@ Another common choice is (\"AI!\" . \"comment line ending with string: AI!\")."
   :type '(cons string string)
   :group 'aider)
 
-;; New function to get command from user and send it prefixed with "/code "
 ;;;###autoload
 (defun aider-code-change ()
-  "Make direct code change given user's prompt."
+  "Change code with Aider.
+If a region is selected, change that specific region.
+If cursor is not in a function, start an architectural discussion.
+If cursor is in a function without a selected region, lets user choose
+between changing the function or starting an architectural discussion."
   (interactive)
-  (let ((command (aider-read-string "Enter code change requirement: ")))
-    (aider-current-file-command-and-switch "/code " command)))
+  (let* ((function-name (which-function))
+         (region-active (region-active-p)))
+    (cond
+     (region-active
+      (aider-function-or-region-change))
+     ((not function-name)
+      (aider-architect-discussion))
+     (t
+      (let ((choice (completing-read
+                     "Choose action: "
+                     (list (format "Change function '%s'" function-name)
+                           "Global code change")
+                     nil t)))
+        (if (string-prefix-p "Change function" choice)
+            (aider-function-or-region-change)
+          (aider-architect-discussion)))))))
 
 ;; New function to get command from user and send it prefixed with "/architect "
 ;;;###autoload

--- a/aider.el
+++ b/aider.el
@@ -115,12 +115,12 @@ Also based on aider LLM benchmark: https://aider.chat/docs/leaderboards/"
 
 ;;; Transient menu items for the “Code Change” section.
 (transient-define-group aider--menu-code-change
-  ("c" "Change Function/Region"      aider-function-or-region-change)
+  ("c" "Code Change with Review"     aider-code-change)
   ("i" "Implement Requirement"       aider-implement-todo)
-  ("t" "Architect Discuss/Change"    aider-architect-discussion)
-  ("U" "Write Unit Test"             aider-write-unit-test)
-  ("F" "Fix Flycheck Errors"         aider-flycheck-fix-errors-in-scope)
+  ;; ("t" "Architect Discuss/Change"    aider-architect-discussion)
   ("r" "Refactor Code"               aider-refactor-book-method)
+  ("F" "Fix Flycheck Errors"         aider-flycheck-fix-errors-in-scope)
+  ("U" "Write Unit Test"             aider-write-unit-test)
   ("T" "Test Driven Development"     aider-tdd-cycle)
   ("l" "Work with Legacy Code"       aider-legacy-code)
   ("B" "Code/Doc Bootstrap"          aider-bootstrap))

--- a/appendix.org
+++ b/appendix.org
@@ -4,9 +4,10 @@
 ** Let aider to fix the errors reported by flycheck
 
 - aider-flycheck-fix-errors-in-scope :: Flycheck output will be sent to aider as context to fix the error. It support:
+  - current line
   - current function
+  - whole file
   - selected region
-  - whole file (C-u)
 
 ** Semi-automatic expansion of context
 

--- a/etc/aider-etc.el
+++ b/etc/aider-etc.el
@@ -105,7 +105,7 @@ If there are more than 40 files, refuse to add and show warning message."
 
 ;; New function to get command from user and send it prefixed with "/code "
 ;;;###autoload
-(defun aider-code-change ()
+(defun aider-code-command ()
   "Make direct code change given user's prompt."
   (interactive)
   (let ((command (aider-read-string "Enter code change requirement: ")))

--- a/etc/aider-etc.el
+++ b/etc/aider-etc.el
@@ -102,3 +102,11 @@ If there are more than 40 files, refuse to add and show warning message."
               (message "Added %d files with suffix .%s"
                        (length files) current-suffix)))
           )))))
+
+;; New function to get command from user and send it prefixed with "/code "
+;;;###autoload
+(defun aider-code-change ()
+  "Make direct code change given user's prompt."
+  (interactive)
+  (let ((command (aider-read-string "Enter code change requirement: ")))
+    (aider-current-file-command-and-switch "/code " command)))


### PR DESCRIPTION
Following example of aider-ask-question: https://github.com/tninja/aider.el/pull/208, simplify regular code change functions to only two:

1. aider-code-change (C-c a c) to change existing code with review process (the one in this PR)
2. aider-implement-todo (C-c a i) to add new code (also with review process)