### PR TITLE
Fix: advice-add work around for (setq-local jit-lock-defer-time 0)

### DIFF
--- a/aider-comint-markdown.el
+++ b/aider-comint-markdown.el
@@ -43,9 +43,17 @@
         (error nil))
     (funcall origfn start end)))
 
+(defun aider--jit-lock-defer-fontification-advice (orig-fn)
+  "Run `jit-lock-defer-fontification' with `jit-lock-defer-time' set to 0 for `aider-comint-mode'."
+  (if (eq major-mode 'aider-comint-mode)
+      (let ((jit-lock-defer-time 0))
+        (funcall orig-fn))
+    (funcall orig-fn)))
+
 (advice-add 'markdown-maybe-funcall-regexp :around #'aider--safe-maybe-funcall-regexp)
 (advice-add 'markdown-get-start-fence-regexp :around #'aider--safe-get-start-fence-regexp)
 (advice-add 'markdown-syntax-propertize-fenced-block-constructs :around #'aider--safe-syntax-propertize-fenced-block-constructs)
+(advice-add 'jit-lock-defer-fontification :around #'aider--jit-lock-defer-fontification-advice)
 
 (defun aider--apply-markdown-highlighting ()
   "Set up markdown highlighting for aider buffer with optimized performance."
@@ -61,12 +69,12 @@
   (setq-local font-lock-multiline t)
   (setq-local jit-lock-contextually nil)
   (setq-local font-lock-support-mode 'jit-lock-mode)
-  (setq-local jit-lock-defer-time 0)
   (font-lock-mode 1)
   (font-lock-flush)
   (font-lock-ensure)
   (add-hook 'syntax-propertize-extend-region-functions
             #'markdown-syntax-propertize-extend-region nil t)
+
   (add-hook 'jit-lock-after-change-extend-region-functions
             #'markdown-font-lock-extend-region-function t t)
   (setq-local markdown-regex-blockquote "^\\_>$")


### PR DESCRIPTION
@blahgeek PTAL, related to https://github.com/tninja/aider.el/issues/210

If `(setq-local jit-lock-defer-time 0)` is the root cause, wonder if this change can help? Would be great if you can verify if this fix the issue.